### PR TITLE
Developed application to parse the survey and return an HTML table

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "apps/inclusions/markdown2docbook"]
+	path = apps/inclusions/markdown2docbook
+	url = https://github.com/msmid/markdown2docbook.git

--- a/apps/inclusions/core-functions.xsl
+++ b/apps/inclusions/core-functions.xsl
@@ -1,0 +1,10 @@
+<xsl:stylesheet 
+   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+   xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+   xmlns:la="https://www.w3.org/community/ld4lt" version="3.0">
+   <!-- CORE FUNCTION LIBRARY FOR LINGUISTIC ANNOTATION -->
+   <!-- This stylesheet is exclusively a function library for including/importing by other master stylesheets -->
+   
+
+   
+</xsl:stylesheet>

--- a/apps/inclusions/tablesorter.js
+++ b/apps/inclusions/tablesorter.js
@@ -1,0 +1,84 @@
+// script below adapted from https://www.w3schools.com/howto/tryit.asp?filename=tryhow_js_sort_table_desc
+function sortTable(n) {
+   var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+   table = document.getElementById("survey");
+   switching = true;
+   dir = "asc";
+   while (switching) {
+      switching = false;
+      rows = table.rows;
+      for (i = 1; i < (rows.length - 1);
+      i++) {
+         shouldSwitch = false;
+         x = rows[i].getElementsByTagName("TD")[n];
+         y = rows[i + 1].getElementsByTagName("TD")[n];
+         xLc = x.innerText.toLowerCase();
+         yLc = y.innerText.toLowerCase();
+         if (dir == "asc") {
+            if (xLc > yLc) {
+               shouldSwitch = true;
+               break;
+            }
+         } else if (dir == "desc") {
+            if (xLc < yLc) {
+               shouldSwitch = true;
+               break;
+            }
+         }
+      }
+      if (shouldSwitch) {
+         rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+         switching = true;
+         switchcount++;
+      } else {
+         if (switchcount == 0 && dir == "asc") {
+            dir = "desc";
+            switching = true;
+         }
+      }
+   }
+}
+function sortTableByNumber(n) {
+   var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+   table = document.getElementById("survey");
+   switching = true;
+   dir = "asc";
+   while (switching) {
+      switching = false;
+      rows = table.rows;
+      for (i = 1; i < (rows.length - 1);
+      i++) {
+         shouldSwitch = false;
+         x = rows[i].getElementsByTagName("TD")[n];
+         y = rows[i + 1].getElementsByTagName("TD")[n];
+         xLc = x.innerText;
+         yLc = y.innerText;
+         if (dir == "asc") {
+            if (Number(xLc) > Number(yLc)) {
+               shouldSwitch = true;
+               break;
+            }
+         } else if (dir == "desc") {
+            if (Number(xLc) < Number(yLc)) {
+               shouldSwitch = true;
+               break;
+            }
+         }
+      }
+      if (shouldSwitch) {
+         rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+         switching = true;
+         switchcount++;
+      } else {
+         if (switchcount == 0 && dir == "asc") {
+            dir = "desc";
+            switching = true;
+         }
+      }
+   }
+}
+
+function reveal(targId) {
+   var x = document.getElementById(targId);
+   x.classList.toggle("hide");
+}

--- a/apps/linguistic-annotation.xpr
+++ b/apps/linguistic-annotation.xpr
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="22.1">
+    <meta>
+        <filters directoryPatterns="" filePatterns="\Qlinguistic-annotation.xpr\E" positiveFilePatterns="" showHiddenFiles="false"/>
+        <options>
+            <serialized version="22.1" xml:space="preserve">
+                <serializableOrderedMap>
+                    <entry>
+                        <String>enable.project.master.files.support</String>
+                        <Boolean>true</Boolean>
+                    </entry>
+                    <entry>
+                        <String>scenario.associations</String>
+                        <scenarioAssociation-array>
+                            <scenarioAssociation>
+                                <field name="url">
+                                    <String>parse%20survey.xsl</String>
+                                </field>
+                                <field name="scenarioIds">
+                                    <list>
+                                        <String>run XSLT against itself html output</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioTypes">
+                                    <list>
+                                        <String>XML</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioStorageLocations">
+                                    <list>
+                                        <Byte>2</Byte>
+                                    </list>
+                                </field>
+                            </scenarioAssociation>
+                        </scenarioAssociation-array>
+                    </entry>
+                    <entry>
+                        <String>scenarios</String>
+                        <scenario-array>
+                            <scenario>
+                                <field name="advancedOptionsMap">
+                                    <null/>
+                                </field>
+                                <field name="name">
+                                    <String>run XSLT against itself</String>
+                                </field>
+                                <field name="baseURL">
+                                    <String></String>
+                                </field>
+                                <field name="footerURL">
+                                    <String></String>
+                                </field>
+                                <field name="fOPMethod">
+                                    <String>pdf</String>
+                                </field>
+                                <field name="fOProcessorName">
+                                    <String>Apache FOP</String>
+                                </field>
+                                <field name="headerURL">
+                                    <String></String>
+                                </field>
+                                <field name="inputXSLURL">
+                                    <String>${currentFileURL}</String>
+                                </field>
+                                <field name="inputXMLURL">
+                                    <String>${currentFileURL}</String>
+                                </field>
+                                <field name="defaultScenario">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="isFOPPerforming">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="type">
+                                    <String>XML</String>
+                                </field>
+                                <field name="saveAs">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="openInBrowser">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="outputResource">
+                                    <String>${currentFileURL}-output.xml</String>
+                                </field>
+                                <field name="openOtherLocationInBrowser">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="locationToOpenInBrowserURL">
+                                    <null/>
+                                </field>
+                                <field name="openInEditor">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="showInHTMLPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInXMLPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInSVGPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInResultSetPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="useXSLTInput">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="xsltParams">
+                                    <list/>
+                                </field>
+                                <field name="cascadingStylesheets">
+                                    <String-array/>
+                                </field>
+                                <field name="xslTransformer">
+                                    <String>Saxon-PE</String>
+                                </field>
+                                <field name="extensionURLs">
+                                    <String-array/>
+                                </field>
+                            </scenario>
+                            <scenario>
+                                <field name="advancedOptionsMap">
+                                    <null/>
+                                </field>
+                                <field name="name">
+                                    <String>run XSLT against itself html output</String>
+                                </field>
+                                <field name="baseURL">
+                                    <String></String>
+                                </field>
+                                <field name="footerURL">
+                                    <String></String>
+                                </field>
+                                <field name="fOPMethod">
+                                    <String>pdf</String>
+                                </field>
+                                <field name="fOProcessorName">
+                                    <String>Apache FOP</String>
+                                </field>
+                                <field name="headerURL">
+                                    <String></String>
+                                </field>
+                                <field name="inputXSLURL">
+                                    <String>${currentFileURL}</String>
+                                </field>
+                                <field name="inputXMLURL">
+                                    <String>${currentFileURL}</String>
+                                </field>
+                                <field name="defaultScenario">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="isFOPPerforming">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="type">
+                                    <String>XML</String>
+                                </field>
+                                <field name="saveAs">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="openInBrowser">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="outputResource">
+                                    <String>${currentFileURL}-output.html</String>
+                                </field>
+                                <field name="openOtherLocationInBrowser">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="locationToOpenInBrowserURL">
+                                    <null/>
+                                </field>
+                                <field name="openInEditor">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInHTMLPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInXMLPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInSVGPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showInResultSetPane">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="useXSLTInput">
+                                    <Boolean>true</Boolean>
+                                </field>
+                                <field name="xsltParams">
+                                    <list/>
+                                </field>
+                                <field name="cascadingStylesheets">
+                                    <String-array/>
+                                </field>
+                                <field name="xslTransformer">
+                                    <String>Saxon-PE</String>
+                                </field>
+                                <field name="extensionURLs">
+                                    <String-array/>
+                                </field>
+                            </scenario>
+                        </scenario-array>
+                    </entry>
+                </serializableOrderedMap>
+            </serialized>
+        </options>
+    </meta>
+    <projectTree name="linguistic-annotation.xpr">
+        <folder path="."/>
+        <folder path="../doc/"/>
+        <folder path="../survey/"/>
+    </projectTree>
+</project>

--- a/apps/parse survey.xsl
+++ b/apps/parse survey.xsl
@@ -1,0 +1,419 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   xmlns:la="https://www.w3.org/community/ld4lt"
+   xmlns:doc="http://docbook.org/ns/docbook"
+   xmlns:md2doc="http://www.markdown2docbook.com/ns/md2doc"
+   version="3.0">
+   <!-- APPLICATION FOR PARSING THE LINGUISTIC ANNOTATION SURVEY OF REQUIRED FEATURES -->
+   
+   <!-- Initial, catalyzing input: any XML file, including this one -->
+   <!-- Secondary (main) input: ../survey/required-features.md -->
+   <!-- Primary output: depending upon how the static parameters are configured, either:
+               1. Diagnostics
+                  OR
+               2. An HTML page showing the aspects supported by each candidate language
+   -->
+   <!-- Secondary output: none -->
+   
+   <xsl:param name="output-diagnostics-on" static="yes" as="xs:boolean" select="false()"/>
+   
+   <xsl:output indent="yes" use-when="$output-diagnostics-on"/>
+   <xsl:output indent="yes" method="html" use-when="not($output-diagnostics-on)" use-character-maps="keep-chars"/>
+   
+   
+   
+   <xsl:include href="inclusions/core-functions.xsl"/>
+   <xsl:include href="inclusions/markdown2docbook/src/md2doc-functions.xsl"/>
+   
+   <xsl:param name="required-features-uri-resolved" select="resolve-uri('../survey/required-features.md', static-base-uri())"/>
+   <xsl:variable name="required-features-unparsed" select="unparsed-text($required-features-uri-resolved)"/>
+   <!-- The current document has a code line that begins #, throwing off the docbook parser -->
+   <xsl:variable name="required-features-adjusted" select="replace($required-features-unparsed, '# WORD', ' $0')"/>
+   
+   <xsl:character-map name="keep-chars">
+      <!-- For retaining JavaScript characters -->
+      <xsl:output-character character="&lt;" string="&lt;"/>
+      <xsl:output-character character="&gt;" string="&gt;"/>
+      <xsl:output-character character="&amp;" string="&amp;"/>
+      <xsl:output-character character="&#xd;" string=""/>
+   </xsl:character-map>
+   
+   
+   <!-- Default templates -->
+   <xsl:template match="document-node()" mode="#all">
+      <xsl:document>
+         <xsl:apply-templates mode="#current"/>
+      </xsl:document>
+   </xsl:template>
+   
+   <!-- Turn the markdown document into DocBook -->
+   <xsl:variable name="required-features-as-docbook" as="document-node()">
+      <xsl:document>
+         <xsl:sequence select="md2doc:convert($required-features-adjusted, 'article', '')"/>
+      </xsl:document>
+   </xsl:variable>
+   
+   <!-- Turn the markdown document into HTML -->
+   <xsl:variable name="required-features-as-html" as="document-node()">
+      <xsl:document>
+         <xsl:sequence select="md2doc:get-html($required-features-adjusted)"/>
+      </xsl:document>
+   </xsl:variable>
+   
+   <xsl:variable name="standards-tree" as="element()">
+      <standards>
+         <standard>
+            <name>NIF</name>
+            <version>
+               <name>NIF 2.0</name>
+            </version>
+            <version>
+               <name>NIF 2.1</name>
+            </version>
+            <extension>
+               <name>CoNLL-RDF</name>
+            </extension>
+            <extension>
+               <name>Ligt</name>
+            </extension>
+         </standard>
+         <standard>
+            <name>Web Annotation</name>
+            <name>Open Annotation</name>
+         </standard>
+         <group>
+            <name>ISO and derivatives</name>
+            <standard>
+               <name>POWLA</name>
+               <name>PAULA</name>
+            </standard>
+            <standard>
+               <name>LAF</name>
+            </standard>
+            <standard>
+               <name>MAF</name>
+            </standard>
+            <standard>
+               <name>SynAF</name>
+            </standard>
+            <standard>
+               <name>SemAF</name>
+            </standard>
+         </group>
+      </standards>
+   </xsl:variable>
+   
+   <xsl:variable name="parse-pass-1" as="document-node()">
+      <xsl:document>
+         <survey>
+            <xsl:apply-templates select="$required-features-as-docbook"
+               mode="docbook-to-req-feat-db"/>
+         </survey>
+      </xsl:document>
+   </xsl:variable>
+   
+   <xsl:mode name="docbook-to-req-feat-db" on-no-match="shallow-skip"/>
+   <xsl:template match="doc:para" mode="docbook-to-req-feat-db">
+      <xsl:variable name="this-element" select="."/>
+      <xsl:variable name="this-leaf-section" select="ancestor::doc:section[1]" as="element()?"/>
+      <xsl:variable name="this-support-value" select="$this-element/doc:computeroutput[matches(., '[+-]')][1]"/>
+      <xsl:variable name="this-comment" select="$this-support-value/following-sibling::node()"/>
+      <xsl:variable name="this-comment-norm" select="normalize-space(replace(string-join($this-comment), '^[\W]+|[\W+]$', ''))"/>
+      <xsl:variable name="these-entries" as="xs:string*">
+         <xsl:analyze-string select="." regex="^([,a-zA-Z .-]+):">
+            <xsl:matching-substring>
+               <xsl:copy-of select="tokenize(regex-group(1), '[\s,]+')"/>
+            </xsl:matching-substring>
+         </xsl:analyze-string>
+      </xsl:variable>
+      <xsl:variable name="these-standards-tree-entries" select="$standards-tree//*[name = $these-entries]"/>
+      <xsl:for-each select="$these-standards-tree-entries">
+         <xsl:variable name="these-versions" select=".//version" as="element()*"/>
+         <!-- Let something like NIF populate down to NIF 2.0 etc. -->
+         <xsl:variable name="these-names-norm"
+            select="
+               if (exists($these-versions)) then
+                  $these-versions/name[1]
+               else
+                  name[1]"/>
+         <item>
+            <aspect>
+               <xsl:value-of select="$this-leaf-section[1]/doc:title[1]"/>
+            </aspect>
+            <xsl:for-each select="$these-names-norm">
+               <standard>
+                  <xsl:value-of select="."/>
+               </standard>
+            </xsl:for-each>
+            <support>
+               <xsl:value-of select="$this-element/doc:computeroutput[matches(., '[+-]')][1]"/>
+            </support>
+            <xsl:if test="string-length($this-comment-norm) gt 0">
+               <comment>
+                  <xsl:value-of select="$this-comment-norm"/>
+               </comment>
+            </xsl:if>
+         </item>
+      </xsl:for-each>
+      
+   </xsl:template>
+   
+   <xsl:variable name="leaf-sections" as="element()+" select="$required-features-as-docbook//doc:section[not(doc:section)]"/>
+   
+   <xsl:variable name="parse-pass-2" as="document-node()">
+      <xsl:apply-templates select="$parse-pass-1" mode="data-to-table"/>
+   </xsl:variable>
+   <xsl:template match="/*" mode="data-to-table">
+      <xsl:copy>
+         <xsl:copy-of select="@*"/>
+         <xsl:for-each select="$leaf-sections">
+            <xsl:variable name="this-title" select="doc:title" as="element()"/>
+            <xsl:variable name="these-data" select="$parse-pass-1/*/item[aspect = $this-title]"/>
+            <row>
+               <key>
+                  <xsl:value-of select="$this-title"/>
+               </key>
+               <xsl:for-each select="$standards-tree//*[name][not(standard)][not(version)]">
+                  <xsl:variable name="these-names" select="name"/>
+                  <xsl:variable name="data-for-this-standard" select="$these-data[standard = $these-names]"/>
+                  <cell class="{replace($these-names[1], ' ', '_')}">
+                     <xsl:copy-of select="$data-for-this-standard/support"/>
+                     <xsl:copy-of select="$data-for-this-standard/comment"/>
+                  </cell>
+               </xsl:for-each>
+            </row>
+         </xsl:for-each> 
+      </xsl:copy>
+   </xsl:template>
+   
+   <xsl:variable name="parse-pass-3" as="document-node()">
+      <xsl:apply-templates select="$parse-pass-2" mode="calculate-scores"/>
+   </xsl:variable>
+   <xsl:mode name="calculate-scores" on-no-match="shallow-copy"/>
+   <xsl:template match="/*" mode="calculate-scores">
+      <xsl:variable name="these-rows" select="row" as="element()*"/>
+      <xsl:copy>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates mode="#current"/>
+         <row class="score">
+            <key>score</key>
+            <xsl:for-each select="1 to count(row[1]/cell)">
+               <xsl:variable name="this-pos" select="."/>
+               <xsl:variable name="these-cells" select="$these-rows/cell[$this-pos]"/>
+               <cell>
+                  <xsl:copy-of select="$these-cells[1]/@*"/>
+                  <xsl:value-of select="la:calculate-score($these-cells)"/>
+               </cell>
+            </xsl:for-each>
+            <cell/>
+         </row>
+      </xsl:copy>
+   </xsl:template>
+   <!-- Skip rows that have no entries -->
+   <xsl:template match="row[not(cell/support)]" mode="calculate-scores"/>
+   <xsl:template match="row" mode="calculate-scores">
+      <xsl:copy>
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates mode="#current"/>
+         <cell class="score">
+            <xsl:value-of select="la:calculate-score(cell/support)"/>
+         </cell>
+      </xsl:copy>
+   </xsl:template>
+   
+   <xsl:function name="la:calculate-score" as="xs:double?">
+      <!-- Input: any items -->
+      <!-- Output: a calculated score, where + alone is 1, (+) is 0.5, (-) is -0.5 and - is -1 -->
+      <xsl:param name="labels" as="item()*"/>
+      <xsl:variable name="these-scores" as="xs:double*">
+         <xsl:for-each select="$labels">
+            <xsl:choose>
+               <xsl:when test=". eq '+'">
+                  <xsl:sequence select="1"/>
+               </xsl:when>
+               <xsl:when test=". eq '(+)'">
+                  <xsl:sequence select="0.5"/>
+               </xsl:when>
+               <xsl:when test=". eq '(-)'">
+                  <xsl:sequence select="-0.5"/>
+               </xsl:when>
+               <xsl:when test=". eq '-'">
+                  <xsl:sequence select="-1"/>
+               </xsl:when>
+               <xsl:otherwise>
+                  <xsl:sequence select="0"/>
+               </xsl:otherwise>
+            </xsl:choose>
+         </xsl:for-each>
+      </xsl:variable>
+      <xsl:sequence select="sum($these-scores)"/>
+   </xsl:function>
+   
+   <xsl:variable name="results-as-html" as="document-node()">
+      <xsl:apply-templates select="$parse-pass-3" mode="parse-to-html"/>
+   </xsl:variable>
+   <xsl:template match="/*" mode="parse-to-html">
+      <html xmlns="http://www.w3.org/1999/xhtml">
+         <head>
+            <title>
+               <xsl:text>Linguistic Annotation Survey generated </xsl:text>
+               <xsl:value-of select="current-dateTime()"/>
+            </title>
+            <style>
+               table {
+               border-spacing: 0;
+               width: 100%;
+               border: 1px solid #ddd;
+               }
+               th {
+               cursor: pointer;
+               text-align: center;
+               padding: 1em;
+               }
+               td {
+               text-align: right;
+               padding: 1em;
+               }
+               tr:nth-child(even) {
+               background-color: #f2f2f2;
+               }
+               .support{
+               text-align: center;}
+               .comment{
+               text-align: left;
+               }
+               .hascomment{
+               background-color: lightgray;
+               cursor: pointer;
+               }
+               .hide{
+               display: none;
+               }
+               .sup4{
+               background-color: #33ff33;
+               }
+               .sup3{
+               background-color: #ccffcc;
+               }
+               .sup2{
+               background-color: #ffff66;
+               }
+               .sup1{
+               background-color: #ff6666;
+               }
+            </style>
+         </head>
+         <body>
+            <h1>Linguistic Annotation Survey</h1>
+            <div>Generated <xsl:value-of select="current-dateTime()"/> from stylsheet at <xsl:value-of select="static-base-uri()"/></div>
+            <h2>Key</h2>
+            <div>Some criteria below assign specific meaning to the four codes. Default values, however, are as follows:</div>
+            <div><code>+</code>: criterium is fully supported (score 1)</div>
+            <div><code>(+)</code>: criterium is partly supported, or offers potential for full support via extensions (score 0.5)</div>
+            <div><code>(-)</code>: criterium is not supported, but might be extended to partial or full support (score -0.5)</div>
+            <div><code>-</code>: criterium is not supported, and cannot be extended to develop partial or full support (score -1)</div>
+            <h2>Survey</h2>
+            <table id="survey">
+               <thead>
+                  <xsl:apply-templates select="row[1]" mode="build-thead"/>
+               </thead>
+               <tbody>
+                  <xsl:apply-templates mode="#current"/>
+               </tbody>
+            </table>
+            <script xml:space="preserve"><xsl:value-of select="unparsed-text('inclusions/tablesorter.js')"/></script>
+         </body>
+      </html>
+   </xsl:template>
+   
+   <xsl:template match="row/*" mode="build-thead">
+      <th xmlns="http://www.w3.org/1999/xhtml" onclick="sortTable({count(preceding-sibling::*)})">
+         <xsl:copy-of select="@*"/>
+         <xsl:value-of select="@class"/>
+      </th>
+   </xsl:template>
+   <xsl:template match="row/*[last()]" priority="1" mode="build-thead">
+      <th xmlns="http://www.w3.org/1999/xhtml" onclick="sortTableByNumber({count(preceding-sibling::*)})">
+         <xsl:copy-of select="@*"/>
+         <xsl:value-of select="@class"/>
+      </th>
+   </xsl:template>
+   <xsl:template match="row" mode="parse-to-html build-thead">
+      <tr xmlns="http://www.w3.org/1999/xhtml">
+         <xsl:copy-of select="@*"/>
+         <xsl:apply-templates mode="#current"/>
+      </tr>
+   </xsl:template>
+   <xsl:template match="key | cell" mode="parse-to-html">
+      <xsl:variable name="this-support-value" select="la:calculate-score(support)" as="xs:double?"/>
+      <xsl:variable name="this-extra-class-name" as="xs:string?">
+         <xsl:choose>
+            <xsl:when test="$this-support-value eq 1">sup4</xsl:when>
+            <xsl:when test="$this-support-value eq 0.5">sup3</xsl:when>
+            <xsl:when test="$this-support-value eq -0.5">sup2</xsl:when>
+            <xsl:when test="$this-support-value eq -1">sup1</xsl:when>
+         </xsl:choose>
+      </xsl:variable>
+      <td xmlns="http://www.w3.org/1999/xhtml">
+         <xsl:copy-of select="@*"/>
+         <xsl:attribute name="class" select="string-join((@class, $this-extra-class-name), ' ')"/>
+         <xsl:apply-templates mode="#current">
+            <xsl:with-param name="comment-id"
+               select="
+                  if (exists(comment)) then
+                     generate-id(comment[1])
+                  else
+                     ()"
+               as="xs:string?"/>
+         </xsl:apply-templates>
+      </td>
+   </xsl:template>
+   <xsl:template match="support" mode="parse-to-html">
+      <xsl:param name="comment-id" as="xs:string?"/>
+      <xsl:variable name="has-comment" select="string-length($comment-id) gt 0" as="xs:boolean"/>
+      <xsl:variable name="this-class-val" select="if ($has-comment) then 'support hascomment' else 'support'"/>
+      <!-- For alphabetical sorting -->
+      <div class="hide score">
+         <xsl:value-of select="round((la:calculate-score(.) + 2) * 2)"/>
+      </div>
+      <div xmlns="http://www.w3.org/1999/xhtml" class="{$this-class-val}">
+         <xsl:if test="$has-comment">
+            <xsl:attribute name="onclick">reveal('<xsl:value-of select="$comment-id"
+               />')</xsl:attribute>
+         </xsl:if>
+         <xsl:apply-templates mode="#current"/>
+      </div>
+      
+   </xsl:template>
+   <xsl:template match="comment" mode="parse-to-html">
+      <xsl:param name="comment-id" as="xs:string?"/>
+      <div xmlns="http://www.w3.org/1999/xhtml" class="comment hide">
+         <xsl:if test="string-length($comment-id) gt 0">
+            <xsl:attribute name="id" select="$comment-id"/>
+         </xsl:if>
+         <xsl:apply-templates mode="#current"/>
+      </div>
+   </xsl:template>
+   <xsl:template match="*" mode="parse-to-html">
+      <div xmlns="http://www.w3.org/1999/xhtml" class="{name(.)}">
+         <xsl:apply-templates mode="#current"/>
+      </div>
+   </xsl:template>
+   
+   
+   <xsl:template match="/" priority="2" use-when="$output-diagnostics-on">
+      <diagnostics>
+         <!--<required-features-unparsed><xsl:copy-of select="$required-features-unparsed"/></required-features-unparsed>-->
+         <required-features-as-docbook><xsl:copy-of select="$required-features-as-docbook"/></required-features-as-docbook>
+         <!--<required-features-as-html><xsl:copy-of select="$required-features-as-html"/></required-features-as-html>-->
+         <parse-pass-1><xsl:copy-of select="$parse-pass-1"/></parse-pass-1>
+         <parse-pass-2><xsl:copy-of select="$parse-pass-2"/></parse-pass-2>
+         <parse-pass-3><xsl:copy-of select="$parse-pass-3"/></parse-pass-3>
+         <results-as-html><xsl:copy-of select="$results-as-html"/></results-as-html>
+      </diagnostics>
+   </xsl:template>
+   <xsl:template match="/" priority="1">
+      <xsl:copy-of select="$results-as-html"/>
+   </xsl:template>
+   
+</xsl:stylesheet>

--- a/apps/parse survey.xsl-output.html
+++ b/apps/parse survey.xsl-output.html
@@ -1,0 +1,2304 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:la="https://www.w3.org/community/ld4lt" xmlns:doc="http://docbook.org/ns/docbook" xmlns:md2doc="http://www.markdown2docbook.com/ns/md2doc">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></meta>
+      <title>Linguistic Annotation Survey generated 2020-12-09T07:24:36.103-05:00</title>
+      <style>
+               table {
+               border-spacing: 0;
+               width: 100%;
+               border: 1px solid #ddd;
+               }
+               th {
+               cursor: pointer;
+               text-align: center;
+               padding: 1em;
+               }
+               td {
+               text-align: right;
+               padding: 1em;
+               }
+               tr:nth-child(even) {
+               background-color: #f2f2f2;
+               }
+               .support{
+               text-align: center;}
+               .comment{
+               text-align: left;
+               }
+               .hascomment{
+               background-color: lightgray;
+               cursor: pointer;
+               }
+               .hide{
+               display: none;
+               }
+               .sup4{
+               background-color: #33ff33;
+               }
+               .sup3{
+               background-color: #ccffcc;
+               }
+               .sup2{
+               background-color: #ffff66;
+               }
+               .sup1{
+               background-color: #ff6666;
+               }
+            </style>
+   </head>
+   <body>
+      <h1>Linguistic Annotation Survey</h1>
+      <div>Generated 2020-12-09T07:24:36.103-05:00 from stylsheet at file:/U:/linguistic-annotation/apps/parse%20survey.xsl</div>
+      <h2>Key</h2>
+      <div>Some criteria below assign specific meaning to the four codes. Default values, however, are as follows:</div>
+      <div><code>+</code>: criterium is fully supported (score 1)</div>
+      <div><code>(+)</code>: criterium is partly supported, or offers potential for full support via extensions (score 0.5)</div>
+      <div><code>(-)</code>: criterium is not supported, but might be extended to partial or full support (score -0.5)</div>
+      <div><code>-</code>: criterium is not supported, and cannot be extended to develop partial or full support (score -1)</div>
+      <h2>Survey</h2>
+      <table id="survey">
+         <thead>
+            <tr>
+               <th onclick="sortTable(0)"></th>
+               <th onclick="sortTable(1)" class="NIF_2.0">NIF_2.0</th>
+               <th onclick="sortTable(2)" class="NIF_2.1">NIF_2.1</th>
+               <th onclick="sortTable(3)" class="CoNLL-RDF">CoNLL-RDF</th>
+               <th onclick="sortTable(4)" class="Ligt">Ligt</th>
+               <th onclick="sortTable(5)" class="Web_Annotation">Web_Annotation</th>
+               <th onclick="sortTable(6)" class="POWLA">POWLA</th>
+               <th onclick="sortTable(7)" class="LAF">LAF</th>
+               <th onclick="sortTable(8)" class="MAF">MAF</th>
+               <th onclick="sortTable(9)" class="SynAF">SynAF</th>
+               <th onclick="sortTable(10)" class="SemAF">SemAF</th>
+               <th onclick="sortTableByNumber(11)" class="score">score</th>
+            </tr>
+         </thead>
+         <tbody>
+            <tr>
+               <td class="">A.1 RDF serialization</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e6')">+</div>
+                  <div class="comment hide" id="d1458e6">RDF</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e9')">+</div>
+                  <div class="comment hide" id="d1458e9">RDF</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SynAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SemAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="score">1</td>
+            </tr>
+            <tr>
+               <td class="">A.2 Extent of standardization</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e32')">(+)</div>
+                  <div class="comment hide" id="d1458e32">widely used community standard, and referred to in W3C standards</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e35')">(+)</div>
+                  <div class="comment hide" id="d1458e35">widely used community standard, and referred to in W3C standards</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e38')">(-)</div>
+                  <div class="comment hide" id="d1458e38">some usage, not standardized</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e44')">(+)</div>
+                  <div class="comment hide" id="d1458e44">this basically implements LAF</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="score">4</td>
+            </tr>
+            <tr>
+               <td class="">A.3 Documentation</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e60')">+</div>
+                  <div class="comment hide" id="d1458e60">for NIF 2.0</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e63')">+</div>
+                  <div class="comment hide" id="d1458e63">for NIF 2.0</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e68')">(-)</div>
+                  <div class="comment hide" id="d1458e68">partially documented only</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e72')">(+)</div>
+                  <div class="comment hide" id="d1458e72">on-line documentation dated, more up-to-date documentation in Cimiano et al. 2020, but this is not open access</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e75')">(+)</div>
+                  <div class="comment hide" id="d1458e75">via https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e78')">+</div>
+                  <div class="comment hide" id="d1458e78">link tbc.</div>
+               </td>
+               <td class="SynAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e81')">-</div>
+                  <div class="comment hide" id="d1458e81">unless link/information provided</div>
+               </td>
+               <td class="SemAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e84')">-</div>
+                  <div class="comment hide" id="d1458e84">unless link/information provided</div>
+               </td>
+               <td class="score">2.5</td>
+            </tr>
+            <tr>
+               <td class="">A.4 IRI fragment identifiers for strings</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e96')">-</div>
+                  <div class="comment hide" id="d1458e96">provides token identifiers, not string identifiers. surface string lost in the underlying CoNLL format</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e102')">(-)</div>
+                  <div class="comment hide" id="d1458e102">not specified, to be provided by complementary vocabulary, e.g., NIF or WA</div>
+               </td>
+               <td class="LAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e105')">-</div>
+                  <div class="comment hide" id="d1458e105">proprietary means of defining selectors</div>
+               </td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">-1.5</td>
+            </tr>
+            <tr>
+               <td class="">A.5 Explicit selectors</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e125')">(+)</div>
+                  <div class="comment hide" id="d1458e125">recent publications recommend to rely on external vocabularies instead</div>
+               </td>
+               <td class="LAF"></td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">0.5</td>
+            </tr>
+            <tr>
+               <td class="">A.6 Explicit context strings</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="LAF"></td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">-1</td>
+            </tr>
+            <tr>
+               <td class="">A.7 API specifications for web services</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e157')">+</div>
+                  <div class="comment hide" id="d1458e157">https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e160')">+</div>
+                  <div class="comment hide" id="d1458e160">https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</div>
+               </td>
+               <td class="CoNLL-RDF"></td>
+               <td class="Ligt"></td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA"></td>
+               <td class="LAF"></td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">2</td>
+            </tr>
+            <tr>
+               <td class="">A.8 Assign data categories</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e176')">(+)</div>
+                  <div class="comment hide" id="d1458e176">nif:oliaLink, pointing to OLiA</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e179')">(+)</div>
+                  <div class="comment hide" id="d1458e179">nif:oliaLink, pointing to OLiA</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e182')">(+)</div>
+                  <div class="comment hide" id="d1458e182">Publications and examples feature OLiA links, but only via rdf:type assignments; CoNLL-RDF is a NIF fragment, so, nif:oliaLink could be used</div>
+               </td>
+               <td class="Ligt sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e185')">(+)</div>
+                  <div class="comment hide" id="d1458e185">Not specified, but designed as a NIF fragment, so, nif:oliaLink could be used</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA"></td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e190')">(+)</div>
+                  <div class="comment hide" id="d1458e190">LAF and other ISO/TC37 standards: pointing to ISOCat, no longer maintained, successor solutions are only emerging: CCR, DatCatInfo</div>
+               </td>
+               <td class="MAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="SynAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="SemAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="score">4</td>
+            </tr>
+            <tr>
+               <td class="">A.9 Compatible with Web Annotation vocabulary</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e204')">(+)</div>
+                  <div class="comment hide" id="d1458e204">Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e207')">(+)</div>
+                  <div class="comment hide" id="d1458e207">Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="Ligt sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e217')">(+)</div>
+                  <div class="comment hide" id="d1458e217">A partial reconstruction of LAF within WA has been described by Verspoor et al. 2012, but this does not seem to have been adopted in subsequent research nor evaluated by any third party.</div>
+               </td>
+               <td class="MAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e220')">(+)</div>
+                  <div class="comment hide" id="d1458e220">not checked in detail, but cf. LAF</div>
+               </td>
+               <td class="SynAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e223')">(+)</div>
+                  <div class="comment hide" id="d1458e223">not checked in detail, but cf. LAF</div>
+               </td>
+               <td class="SemAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e226')">(+)</div>
+                  <div class="comment hide" id="d1458e226">not checked in detail, but cf. LAF</div>
+               </td>
+               <td class="score">4.5</td>
+            </tr>
+            <tr>
+               <td class="">A.10 Compatible with NIF 2.0 core vocabulary</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e238')">+</div>
+                  <div class="comment hide" id="d1458e238">extends NIF vocabulary with data structures for one-word-per-line annotations, e.g., CoNLL, SketchEngine formats, see here; note the extension for the encoding of trees by means of POWLA</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e241')">+</div>
+                  <div class="comment hide" id="d1458e241">extends NIF vocabulary with specifications for morphology (interlinear glossed text); still under development, see here</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="LAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e247')">-</div>
+                  <div class="comment hide" id="d1458e247">NIF systematically conflates LAF data structures, see A.11</div>
+               </td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">3.5</td>
+            </tr>
+            <tr>
+               <td class="">A.11 Compatible with ISO standards</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e258')">-</div>
+                  <div class="comment hide" id="d1458e258">no generic data structures for linguistic annotation; conflates regions and nodes, see below</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e261')">-</div>
+                  <div class="comment hide" id="d1458e261">no generic data structures for linguistic annotation; conflates regions and nodes, see below</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e264')">-</div>
+                  <div class="comment hide" id="d1458e264">only a specific subset, possibly SynAF</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e267')">-</div>
+                  <div class="comment hide" id="d1458e267">only a specific subset, possibly MAF</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA"></td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="score">0</td>
+            </tr>
+            <tr>
+               <td class="">B.1 Pointers to primary data</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e290')">(-)</div>
+                  <div class="comment hide" id="d1458e290">pointers to tokens, not primary data</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e293')">(-)</div>
+                  <div class="comment hide" id="d1458e293">pointers to data structures, not primary data</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e297')">(+)</div>
+                  <div class="comment hide" id="d1458e297">offset-based pointers possible, last publications recommend to use external vocabularies</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e300')">+</div>
+                  <div class="comment hide" id="d1458e300">XPointers</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e303')">+</div>
+                  <div class="comment hide" id="d1458e303">from LAF</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e306')">+</div>
+                  <div class="comment hide" id="d1458e306">from LAF</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e309')">+</div>
+                  <div class="comment hide" id="d1458e309">from LAF</div>
+               </td>
+               <td class="score">5.5</td>
+            </tr>
+            <tr>
+               <td class="">B.2 Pointers: Vocabulary for explicit references</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e326')">(+)</div>
+                  <div class="comment hide" id="d1458e326">offset-based pointers possible, last publications recommend to use external vocabularies</div>
+               </td>
+               <td class="LAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e329')">-</div>
+                  <div class="comment hide" id="d1458e329">no RDF statements</div>
+               </td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">-0.5</td>
+            </tr>
+            <tr>
+               <td class="">B.3 Pointers: User-provided selectors</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e340')">-</div>
+                  <div class="comment hide" id="d1458e340">would be considered out of scope</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e343')">-</div>
+                  <div class="comment hide" id="d1458e343">would be considered out of scope</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Ligt"></td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e350')">(+)</div>
+                  <div class="comment hide" id="d1458e350">in combination with Web Annotation</div>
+               </td>
+               <td class="LAF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e353')">(-)</div>
+                  <div class="comment hide" id="d1458e353">actually, this is hard to tell, technically, this would be possible, but there don't seem to be documented examples</div>
+               </td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">-3</td>
+            </tr>
+            <tr>
+               <td class="">B.4 Pointers: Support the annotation of continuous strings</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="score">9</td>
+            </tr>
+            <tr>
+               <td class="">B.5 Pointers: Annotation of discontinuous strings</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e388')">-</div>
+                  <div class="comment hide" id="d1458e388">annotations such as ext:offset_0_14_23_32 are not considered nor supported</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e391')">-</div>
+                  <div class="comment hide" id="d1458e391">annotations such as ext:offset_0_14_23_32 are not considered nor supported</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e394')">(-)</div>
+                  <div class="comment hide" id="d1458e394">not natively, but in combination with POWLA</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e397')">(-)</div>
+                  <div class="comment hide" id="d1458e397">in principle, discontinuous aggregates could exist, but there are no examples for that nor any model in current IGT annotation</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e401')">(+)</div>
+                  <div class="comment hide" id="d1458e401">a terminal is offset-defined, so it apparently has to be a continuous string, but nonterminals can aggregate discontinuous sequences of terminals</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e404')">(+)</div>
+                  <div class="comment hide" id="d1458e404">the existence of discontinuous anchors needs to be confirmed, but nodes can aggregate other nodes regardless of their position</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">-2</td>
+            </tr>
+            <tr>
+               <td class="">B.6 Pointers: Annotation of media files</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA"></td>
+               <td class="LAF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e428')">(-)</div>
+                  <div class="comment hide" id="d1458e428">tbc.</div>
+               </td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">-4.5</td>
+            </tr>
+            <tr>
+               <td class="">B.7 Pointers: Support the annotation of timestamps/timelines</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e448')">(+)</div>
+                  <div class="comment hide" id="d1458e448">if combined with Web Annotation</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e451')">(+)</div>
+                  <div class="comment hide" id="d1458e451">tbc.; CC: I'm pretty sure this has been addressed</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">-3</td>
+            </tr>
+            <tr>
+               <td class="">B.8 Pointers: standoff annotation</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Ligt sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e471')">(+)</div>
+                  <div class="comment hide" id="d1458e471">no examples known</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">5.5</td>
+            </tr>
+            <tr>
+               <td class="">B.9 Generic data structures for linguistic annotation: node != pointer</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e494')">(+)</div>
+                  <div class="comment hide" id="d1458e494">in combination with POWLA</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e497')">(-)</div>
+                  <div class="comment hide" id="d1458e497">unclear</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">0</td>
+            </tr>
+            <tr>
+               <td class="">B.10 Generic data structures for linguistic annotation: zero nodes</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e516')">(+)</div>
+                  <div class="comment hide" id="d1458e516">the default encoding for annotations in NIF is by subclasses of nif:String</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e519')">(+)</div>
+                  <div class="comment hide" id="d1458e519">the default encoding for annotations in NIF is by subclasses of nif:String</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e522')">(+)</div>
+                  <div class="comment hide" id="d1458e522">for zero tokens in underlying CoNLL format</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e528')">+</div>
+                  <div class="comment hide" id="d1458e528">from LAF</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">4.5</td>
+            </tr>
+            <tr>
+               <td class="">B.11.a Non-reified representation of edges</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e544')">(-)</div>
+                  <div class="comment hide" id="d1458e544">nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e547')">(-)</div>
+                  <div class="comment hide" id="d1458e547">nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e550')">(+)</div>
+                  <div class="comment hide" id="d1458e550">for semantic roles only</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e556')">(+)</div>
+                  <div class="comment hide" id="d1458e556">for hierarchical relations only</div>
+               </td>
+               <td class="LAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">-1</td>
+            </tr>
+            <tr>
+               <td class="">B.12 Reified representation of edges (annotation relations)</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e577')">-</div>
+                  <div class="comment hide" id="d1458e577">only in combination with POWLA</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e585')">(+)</div>
+                  <div class="comment hide" id="d1458e585">reification" is not directly applicable to non-RDF data</div>
+               </td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">-2.5</td>
+            </tr>
+            <tr>
+               <td class="">B.13 Generic data structures for linguistic annotation: graphs</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="Ligt sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">4</td>
+            </tr>
+            <tr>
+               <td class="">B.14 Generic data structures for linguistic annotation: annotations</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e620')">(-)</div>
+                  <div class="comment hide" id="d1458e620">nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e623')">(-)</div>
+                  <div class="comment hide" id="d1458e623">nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e626')">(-)</div>
+                  <div class="comment hide" id="d1458e626">not created by default</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e629')">(-)</div>
+                  <div class="comment hide" id="d1458e629">tbc</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e633')">(+)</div>
+                  <div class="comment hide" id="d1458e633">tbc</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">-0.5</td>
+            </tr>
+            <tr>
+               <td class="">B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e649')">(+)</div>
+                  <div class="comment hide" id="d1458e649">via OLiA</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e652')">(+)</div>
+                  <div class="comment hide" id="d1458e652">via OLiA</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e655')">(+)</div>
+                  <div class="comment hide" id="d1458e655">via OLiA</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e658')">(-)</div>
+                  <div class="comment hide" id="d1458e658">no example known</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e662')">(+)</div>
+                  <div class="comment hide" id="d1458e662">via OLiA</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">2.5</td>
+            </tr>
+            <tr>
+               <td class="">B.16 Provenance and confidence</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e678')">(-)</div>
+                  <div class="comment hide" id="d1458e678">NIF 2.0</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e681')">(-)</div>
+                  <div class="comment hide" id="d1458e681">NIF 2.0</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="LAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e691')">-</div>
+                  <div class="comment hide" id="d1458e691">no RDF extension possible</div>
+               </td>
+               <td class="MAF"></td>
+               <td class="SynAF"></td>
+               <td class="SemAF"></td>
+               <td class="score">-3.5</td>
+            </tr>
+            <tr>
+               <td class="">B.17 Concurrent annotation</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e706')">(-)</div>
+                  <div class="comment hide" id="d1458e706">different properties in different columns, controlled by the user</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e709')">(-)</div>
+                  <div class="comment hide" id="d1458e709">no example known</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">-1</td>
+            </tr>
+            <tr>
+               <td class="">B.18 Sequence of annotation units</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e728')">(+)</div>
+                  <div class="comment hide" id="d1458e728">only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e731')">(+)</div>
+                  <div class="comment hide" id="d1458e731">only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e734')">(+)</div>
+                  <div class="comment hide" id="d1458e734">for native CoNLL-RDF annotation units</div>
+               </td>
+               <td class="Ligt sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e737')">(+)</div>
+                  <div class="comment hide" id="d1458e737">for native annotation units</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">4</td>
+            </tr>
+            <tr>
+               <td class="">B.19 annotation values: plain literals</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">6</td>
+            </tr>
+            <tr>
+               <td class="">B.20 annotation values: feature structures</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e784')">(+)</div>
+                  <div class="comment hide" id="d1458e784">can be represented, but are not created by default conversion</div>
+               </td>
+               <td class="Ligt sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e787')">(+)</div>
+                  <div class="comment hide" id="d1458e787">no example known</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e791')">+</div>
+                  <div class="comment hide" id="d1458e791">e.g., using OLiA</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e796')">+</div>
+                  <div class="comment hide" id="d1458e796">tbc</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e799')">+</div>
+                  <div class="comment hide" id="d1458e799">tbc</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="score">8</td>
+            </tr>
+            <tr>
+               <td class="">C.1 Word-level annotations: word unit</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e809')">+</div>
+                  <div class="comment hide" id="d1458e809">nif:Word</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e812')">+</div>
+                  <div class="comment hide" id="d1458e812">nif:Word</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e815')">+</div>
+                  <div class="comment hide" id="d1458e815">nif:Word</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e821')">(+)</div>
+                  <div class="comment hide" id="d1458e821">powla:Terminal, but can be sub-token</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="score">8.5</td>
+            </tr>
+            <tr>
+               <td class="">C.2 Sentence-level annotation: sentence unit</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e837')">+</div>
+                  <div class="comment hide" id="d1458e837">nif:Sentence</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e840')">+</div>
+                  <div class="comment hide" id="d1458e840">nif:Sentence</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e843')">+</div>
+                  <div class="comment hide" id="d1458e843">nif:Sentence</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e849')">(+)</div>
+                  <div class="comment hide" id="d1458e849">powla:Root, but this doesn't have to be sentential</div>
+               </td>
+               <td class="LAF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e852')">(-)</div>
+                  <div class="comment hide" id="d1458e852">tbc.</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e859')">+</div>
+                  <div class="comment hide" id="d1458e859">tbc.</div>
+               </td>
+               <td class="score">6</td>
+            </tr>
+            <tr>
+               <td class="">C.3 morphology: morphological segments</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e868')">(-)</div>
+                  <div class="comment hide" id="d1458e868">no designated vocabulary, can be accessed as substrings, but not in all cases.</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e871')">(-)</div>
+                  <div class="comment hide" id="d1458e871">no designated vocabulary, can be accessed as substrings, but not in all cases.</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e879')">(+)</div>
+                  <div class="comment hide" id="d1458e879">no designated vocabulary, but can be added</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e882')">(+)</div>
+                  <div class="comment hide" id="d1458e882">no designated vocabulary, but can be modelled as segments</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e885')">+</div>
+                  <div class="comment hide" id="d1458e885">tbc.</div>
+               </td>
+               <td class="SynAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e888')">-</div>
+                  <div class="comment hide" id="d1458e888">tbc</div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">0</td>
+            </tr>
+            <tr>
+               <td class="">C.4 syntax/text structure: node labels/types</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e899')">(+)</div>
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e899')">(+)</div>
+                  <div class="comment hide" id="d1458e899">predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e903')">(+)</div>
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e903')">(+)</div>
+                  <div class="comment hide" id="d1458e903">predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e906')">(+)</div>
+                  <div class="comment hide" id="d1458e906">phrase structures can only be expressed in combination with POWLA</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e909')">-</div>
+                  <div class="comment hide" id="d1458e909">no examples for phrase-level annotations</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e913')">+</div>
+                  <div class="comment hide" id="d1458e913">using an external vocabulary, OLiA</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e916')">+</div>
+                  <div class="comment hide" id="d1458e916">ISOcat</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e919')">-</div>
+                  <div class="comment hide" id="d1458e919">no syntax nodes</div>
+               </td>
+               <td class="SynAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e922')">(+)</div>
+                  <div class="comment hide" id="d1458e922">ISOcat, for syntax, but hard-wired data structures only</div>
+               </td>
+               <td class="SemAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e925')">(+)</div>
+                  <div class="comment hide" id="d1458e925">ISOcat, for text/discourse, but hard-wired data structures only</div>
+               </td>
+               <td class="score">3.5</td>
+            </tr>
+            <tr>
+               <td class="">C.5 semantics: node labels/types</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e933')">(-)</div>
+                  <div class="comment hide" id="d1458e933">NIF supports entity linking, but no other form of semantic annotation, hence (-)</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e936')">(-)</div>
+                  <div class="comment hide" id="d1458e936">NIF supports entity linking, but no other form of semantic annotation, hence (-)</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e939')">(-)</div>
+                  <div class="comment hide" id="d1458e939">can be created from CoNLL-RDF data</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e942')">-</div>
+                  <div class="comment hide" id="d1458e942">morphology only</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e946')">+</div>
+                  <div class="comment hide" id="d1458e946">using an external vocabulary, OLiA</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e949')">+</div>
+                  <div class="comment hide" id="d1458e949">ISOcat</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e952')">-</div>
+                  <div class="comment hide" id="d1458e952">morphology only</div>
+               </td>
+               <td class="SynAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e955')">-</div>
+                  <div class="comment hide" id="d1458e955">tbc</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e958')">+</div>
+                  <div class="comment hide" id="d1458e958">tbc</div>
+               </td>
+               <td class="score">-1.5</td>
+            </tr>
+            <tr>
+               <td class="">D.1 Word-level annotation: sequence of words</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e966')">+</div>
+                  <div class="comment hide" id="d1458e966">nif:nextWord</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e969')">+</div>
+                  <div class="comment hide" id="d1458e969">nif:nextWord</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e972')">+</div>
+                  <div class="comment hide" id="d1458e972">nif:nextWord</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e978')">(+)</div>
+                  <div class="comment hide" id="d1458e978">words are not a designated datatype</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e981')">(+)</div>
+                  <div class="comment hide" id="d1458e981">tbc., implicitly via offsets?</div>
+               </td>
+               <td class="MAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e984')">(+)</div>
+                  <div class="comment hide" id="d1458e984">tbc: implicitly via XML?</div>
+               </td>
+               <td class="SynAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e987')">(+)</div>
+                  <div class="comment hide" id="d1458e987">tbc: implicitly via XML?</div>
+               </td>
+               <td class="SemAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e990')">(+)</div>
+                  <div class="comment hide" id="d1458e990">tbc: implcitly via XML?</div>
+               </td>
+               <td class="score">6.5</td>
+            </tr>
+            <tr>
+               <td class="">D.2 Sentence-level annotation: sequence of sentences</td>
+               <td class="NIF_2.0 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e998')">+</div>
+                  <div class="comment hide" id="d1458e998">nif:nextSentence</div>
+               </td>
+               <td class="NIF_2.1 sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1001')">+</div>
+                  <div class="comment hide" id="d1458e1001">nif:nextSentence</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA"></td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1010')">(+)</div>
+                  <div class="comment hide" id="d1458e1010">tbc</div>
+               </td>
+               <td class="MAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1013')">(+)</div>
+                  <div class="comment hide" id="d1458e1013">tbc</div>
+               </td>
+               <td class="SynAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1016')">(+)</div>
+                  <div class="comment hide" id="d1458e1016">tbc</div>
+               </td>
+               <td class="SemAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1019')">(+)</div>
+                  <div class="comment hide" id="d1458e1019">tbc</div>
+               </td>
+               <td class="score">6</td>
+            </tr>
+            <tr>
+               <td class="">D.3 Morphology: sequence of morphological segments</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA"></td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1037')">(+)</div>
+                  <div class="comment hide" id="d1458e1037">tbc</div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SynAF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1042')">(-)</div>
+                  <div class="comment hide" id="d1458e1042">tbc</div>
+               </td>
+               <td class="SemAF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1045')">(-)</div>
+                  <div class="comment hide" id="d1458e1045">tbc</div>
+               </td>
+               <td class="score">-1.5</td>
+            </tr>
+            <tr>
+               <td class="">D.4 Syntax: discontinuous multi-word segments</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1053')">-</div>
+                  <div class="comment hide" id="d1458e1053">NIF phrases are strings, i.e., necessarily continuous</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1056')">-</div>
+                  <div class="comment hide" id="d1458e1056">NIF phrases are strings, i.e., necessarily continuous</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1059')">(-)</div>
+                  <div class="comment hide" id="d1458e1059">no phrases, could be added when combined with POWLA</div>
+               </td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1062')">(-)</div>
+                  <div class="comment hide" id="d1458e1062">no examples known</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1072')">(+)</div>
+                  <div class="comment hide" id="d1458e1072">tbc., syntax is likely the reason for having such nodes in LAF</div>
+               </td>
+               <td class="SemAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1075')">(+)</div>
+                  <div class="comment hide" id="d1458e1075">tbc., in analogy with SynAF?</div>
+               </td>
+               <td class="score">0</td>
+            </tr>
+            <tr>
+               <td class="">D.5 Syntax/text structure: sequence of elements within a phrase</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1083')">(-)</div>
+                  <div class="comment hide" id="d1458e1083">depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1086')">(-)</div>
+                  <div class="comment hide" id="d1458e1086">depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1089')">-</div>
+                  <div class="comment hide" id="d1458e1089">no phrases</div>
+               </td>
+               <td class="Ligt sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1097')">(+)</div>
+                  <div class="comment hide" id="d1458e1097">tbc</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1100')">-</div>
+                  <div class="comment hide" id="d1458e1100">tbc</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1103')">+</div>
+                  <div class="comment hide" id="d1458e1103">tbc</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1106')">+</div>
+                  <div class="comment hide" id="d1458e1106">tbc., e.g., for discourse annotation</div>
+               </td>
+               <td class="score">1.5</td>
+            </tr>
+            <tr>
+               <td class="">E.1 Morphology: relations</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1114')">-</div>
+                  <div class="comment hide" id="d1458e1114">no morphologial segmentation</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1117')">-</div>
+                  <div class="comment hide" id="d1458e1117">no morphologial segmentation</div>
+               </td>
+               <td class="CoNLL-RDF"></td>
+               <td class="Ligt sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1121')">(-)</div>
+                  <div class="comment hide" id="d1458e1121">no examples, via link with OntoLex-Morph?</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1125')">(-)</div>
+                  <div class="comment hide" id="d1458e1125">via link with OntoLex-Morph?</div>
+               </td>
+               <td class="LAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="MAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1130')">+</div>
+                  <div class="comment hide" id="d1458e1130">tbc</div>
+               </td>
+               <td class="SynAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1133')">-</div>
+                  <div class="comment hide" id="d1458e1133">tbc</div>
+               </td>
+               <td class="SemAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1136')">-</div>
+                  <div class="comment hide" id="d1458e1136">tbc</div>
+               </td>
+               <td class="score">-4</td>
+            </tr>
+            <tr>
+               <td class="">E.2 Dependency syntax</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1144')">(+)</div>
+                  <div class="comment hide" id="d1458e1144">not part of NIF core, but example implementation with OLiA for Stanford Parser</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1147')">(+)</div>
+                  <div class="comment hide" id="d1458e1147">not part of NIF core, but example implementation with OLiA for Stanford Parser</div>
+               </td>
+               <td class="CoNLL-RDF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1150')">+</div>
+                  <div class="comment hide" id="d1458e1150">native vocabulary</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1156')">(+)</div>
+                  <div class="comment hide" id="d1458e1156">via external vocabulary, e.g., OLiA</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1159')">(+)</div>
+                  <div class="comment hide" id="d1458e1159">voa external vocabulary: ISOcat</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1164')">+</div>
+                  <div class="comment hide" id="d1458e1164">tbc</div>
+               </td>
+               <td class="SemAF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1167')">(-)</div>
+                  <div class="comment hide" id="d1458e1167">tbc</div>
+               </td>
+               <td class="score">1.5</td>
+            </tr>
+            <tr>
+               <td class="">E.3 Phrase structure syntax: hierarchical relations</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1175')">(-)</div>
+                  <div class="comment hide" id="d1458e1175">labelled edges do not seem be foreseen, must be encoded as phrase-level features</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1178')">(-)</div>
+                  <div class="comment hide" id="d1458e1178">labelled edges do not seem be foreseen, must be encoded as phrase-level features</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1181')">(-)</div>
+                  <div class="comment hide" id="d1458e1181">via POWLA and OLiA</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1187')">(+)</div>
+                  <div class="comment hide" id="d1458e1187">labels via external vocabulary, OLiA</div>
+               </td>
+               <td class="LAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1190')">+</div>
+                  <div class="comment hide" id="d1458e1190">via external vocabulary, ISOcat</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1195')">+</div>
+                  <div class="comment hide" id="d1458e1195">tbc</div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">-1</td>
+            </tr>
+            <tr>
+               <td class="">E.4 Phrase structure syntax: other relations</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="CoNLL-RDF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1210')">(-)</div>
+                  <div class="comment hide" id="d1458e1210">support for Penn-style encoding of traces and coindexing, these need to be manually resolved, though</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1216')">(+)</div>
+                  <div class="comment hide" id="d1458e1216">via external vocabulary, e.g., OLiA</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1219')">(+)</div>
+                  <div class="comment hide" id="d1458e1219">via external vocabulary, ISOCat</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SynAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">-1.5</td>
+            </tr>
+            <tr>
+               <td class="">E.5 Semantics: relations</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1233')">(-)</div>
+                  <div class="comment hide" id="d1458e1233">can be extended, e.g., a FrameNet extension, using a separate namespace</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1236')">(-)</div>
+                  <div class="comment hide" id="d1458e1236">can be extended, e.g., a FrameNet extension, using a separate namespace</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1239')">(+)</div>
+                  <div class="comment hide" id="d1458e1239">native support for semantic roles</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1245')">(+)</div>
+                  <div class="comment hide" id="d1458e1245">via OLiA</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1248')">(+)</div>
+                  <div class="comment hide" id="d1458e1248">via ISOcat</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SynAF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1253')">(-)</div>
+                  <div class="comment hide" id="d1458e1253">tbc.</div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support">+</div>
+               </td>
+               <td class="score">-1</td>
+            </tr>
+            <tr>
+               <td class="">F.1 Intertextual relations</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1267')">(+)</div>
+                  <div class="comment hide" id="d1458e1267">a partial linking functionality can be implemented using CoNLL-Merge, then corresponding tokens in different editions refer to the same nif:Word -- which may be an empty token, see alignment below</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA"></td>
+               <td class="LAF sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1274')">(-)</div>
+                  <div class="comment hide" id="d1458e1274">tbc.</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SynAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SemAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1281')">-</div>
+                  <div class="comment hide" id="d1458e1281">tbc</div>
+               </td>
+               <td class="score">-5</td>
+            </tr>
+            <tr>
+               <td class="">F.2 Collation and alignment</td>
+               <td class="NIF_2.0 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="NIF_2.1 sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support">(-)</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1293')">(+)</div>
+                  <div class="comment hide" id="d1458e1293">directed alignment only, encoded in CoNLL columns, i.e., CoNLL-RDF properties, cf. here</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup2">
+                  <div xmlns="" class="hide score">3</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1299')">(-)</div>
+                  <div class="comment hide" id="d1458e1299">can be extended</div>
+               </td>
+               <td class="LAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1302')">-</div>
+                  <div class="comment hide" id="d1458e1302">tbc., no examples known</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="SynAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1307')">-</div>
+                  <div class="comment hide" id="d1458e1307">tbc</div>
+               </td>
+               <td class="SemAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1310')">-</div>
+                  <div class="comment hide" id="d1458e1310">tbc</div>
+               </td>
+               <td class="score">-6</td>
+            </tr>
+            <tr>
+               <td class="">F.3 Links with lexical resources</td>
+               <td class="NIF_2.0 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="NIF_2.1 sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="CoNLL-RDF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="Ligt sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support">(+)</div>
+               </td>
+               <td class="LAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="MAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="score">2.5</td>
+            </tr>
+            <tr>
+               <td class="">F.4 Dialog annotation</td>
+               <td class="NIF_2.0 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1342')">-</div>
+                  <div class="comment hide" id="d1458e1342">Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</div>
+               </td>
+               <td class="NIF_2.1 sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1345')">-</div>
+                  <div class="comment hide" id="d1458e1345">Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</div>
+               </td>
+               <td class="CoNLL-RDF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1348')">-</div>
+                  <div class="comment hide" id="d1458e1348">only if annotated as plain text, no formal vocabulary</div>
+               </td>
+               <td class="Ligt sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support">-</div>
+               </td>
+               <td class="Web_Annotation"></td>
+               <td class="POWLA sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1354')">(+)</div>
+                  <div class="comment hide" id="d1458e1354">extensible</div>
+               </td>
+               <td class="LAF sup3">
+                  <div xmlns="" class="hide score">5</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1357')">(+)</div>
+                  <div class="comment hide" id="d1458e1357">tbc., via ISOcat?</div>
+               </td>
+               <td class="MAF sup1">
+                  <div xmlns="" class="hide score">2</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1360')">-</div>
+                  <div class="comment hide" id="d1458e1360">tbc</div>
+               </td>
+               <td class="SynAF">
+                  <div xmlns="" class="hide score">4</div>
+                  <div class="support"></div>
+               </td>
+               <td class="SemAF sup4">
+                  <div xmlns="" class="hide score">6</div>
+                  <div class="support hascomment" onclick="reveal('d1458e1365')">+</div>
+                  <div class="comment hide" id="d1458e1365">tbc</div>
+               </td>
+               <td class="score">-3</td>
+            </tr>
+            <tr class="score">
+               <td class="">score</td>
+               <td class="NIF_2.0">3.5</td>
+               <td class="NIF_2.1">3.5</td>
+               <td class="CoNLL-RDF">-1</td>
+               <td class="Ligt">-4</td>
+               <td class="Web_Annotation">0</td>
+               <td class="POWLA">11</td>
+               <td class="LAF">14</td>
+               <td class="MAF">-1.5</td>
+               <td class="SynAF">4.5</td>
+               <td class="SemAF">5.5</td>
+               <td class=""></td>
+            </tr>
+         </tbody>
+      </table><script xml:space="preserve">// script below adapted from https://www.w3schools.com/howto/tryit.asp?filename=tryhow_js_sort_table_desc
+function sortTable(n) {
+   var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+   table = document.getElementById("survey");
+   switching = true;
+   dir = "asc";
+   while (switching) {
+      switching = false;
+      rows = table.rows;
+      for (i = 1; i < (rows.length - 1);
+      i++) {
+         shouldSwitch = false;
+         x = rows[i].getElementsByTagName("TD")[n];
+         y = rows[i + 1].getElementsByTagName("TD")[n];
+         xLc = x.innerText.toLowerCase();
+         yLc = y.innerText.toLowerCase();
+         if (dir == "asc") {
+            if (xLc > yLc) {
+               shouldSwitch = true;
+               break;
+            }
+         } else if (dir == "desc") {
+            if (xLc < yLc) {
+               shouldSwitch = true;
+               break;
+            }
+         }
+      }
+      if (shouldSwitch) {
+         rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+         switching = true;
+         switchcount++;
+      } else {
+         if (switchcount == 0 && dir == "asc") {
+            dir = "desc";
+            switching = true;
+         }
+      }
+   }
+}
+function sortTableByNumber(n) {
+   var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+   table = document.getElementById("survey");
+   switching = true;
+   dir = "asc";
+   while (switching) {
+      switching = false;
+      rows = table.rows;
+      for (i = 1; i < (rows.length - 1);
+      i++) {
+         shouldSwitch = false;
+         x = rows[i].getElementsByTagName("TD")[n];
+         y = rows[i + 1].getElementsByTagName("TD")[n];
+         xLc = x.innerText;
+         yLc = y.innerText;
+         if (dir == "asc") {
+            if (Number(xLc) > Number(yLc)) {
+               shouldSwitch = true;
+               break;
+            }
+         } else if (dir == "desc") {
+            if (Number(xLc) < Number(yLc)) {
+               shouldSwitch = true;
+               break;
+            }
+         }
+      }
+      if (shouldSwitch) {
+         rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+         switching = true;
+         switchcount++;
+      } else {
+         if (switchcount == 0 && dir == "asc") {
+            dir = "desc";
+            switching = true;
+         }
+      }
+   }
+}
+
+function reveal(targId) {
+   var x = document.getElementById(targId);
+   x.classList.toggle("hide");
+}
+</script></body>
+</html>

--- a/apps/parse survey.xsl-output.xml
+++ b/apps/parse survey.xsl-output.xml
@@ -1,0 +1,8742 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<diagnostics xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:la="https://www.w3.org/community/ld4lt"
+             xmlns:doc="http://docbook.org/ns/docbook"
+             xmlns:md2doc="http://www.markdown2docbook.com/ns/md2doc">
+   <required-features-as-docbook>
+      <section xmlns:xl="http://www.w3.org/1999/xlink"
+               xmlns="http://docbook.org/ns/docbook"
+               version="5">
+         <title>Required features</title>
+         <para>Feature requests for a LLOD-compliant, native RDF vocabulary for linguistic annotations on the web
+(includes current NIF/WebAnnotation/LAF features, unsupported use cases in NIF and/or Web Annotation, and prospective use cases)</para>
+         <para>List will be used to compile a compliancy table for NIF, Web Annotation and other vocabularies, with primary values <computeroutput>+</computeroutput>, <computeroutput>(+)</computeroutput>, <computeroutput>(-)</computeroutput> and <computeroutput>-</computeroutput>.
+Note: The section numbers below are used to identify entries in the result table. Do not change! (Instead, mark a section/feature as deprecated if it's dropped or replaced by a different feature request.)</para>
+         <para>Add required features for a reference vocabuilary for linguistic annotations on the web here <emphasis>or</emphasis>
+            <link xl:href="https://github.com/ld4lt/linguistic-annotation/issues">as an issue</link>.</para>
+         <section>
+            <title>Table of contents</title>
+            <para>
+(auto-generated using https://magnetikonline.github.io/markdown-toc-generate/, needs to be updated when changes are being made)</para>
+            <itemizedlist>
+               <listitem>
+                  <para>
+                     <link xl:href="#a-llod-compliancy">A. LLOD compliancy</link>
+                  </para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a1-rdf-serialization">A.1 RDF serialization</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a2-extent-of-standardization">A.2 Extent of standardization</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a3-documentation">A.3 Documentation</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a4-iri-fragment-identifiers-for-strings">A.4 IRI fragment identifiers for strings</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a5-explicit-selectors">A.5 Explicit selectors</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a6-explicit-context-strings">A.6 Explicit context strings</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a7-api-specifications-for-web-services">A.7 API specifications for web services</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a8-assign-data-categories">A.8 Assign data categories</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a9-compatible-with-web-annotation-vocabulary">A.9 Compatible with Web Annotation vocabulary</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a10-compatible-with-nif-20-core-vocabulary">A.10 Compatible with NIF 2.0 core vocabulary</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#a11-compatible-with-iso-standards">A.11 Compatible with ISO standards</link>
+                        </para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+               <listitem>
+                  <para>
+                     <link xl:href="#b-expressiveness">B. Expressiveness</link>
+                  </para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b1-pointers-to-primary-data">B.1 Pointers to primary data</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b2-pointers-vocabulary-for-explicit-references">B.2 Pointers: Vocabulary for explicit references</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b3-pointers-user-provided-selectors">B.3 Pointers: User-provided selectors</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b4-pointers-support-the-annotation-of-continuous-strings">B.4 Pointers: Support the annotation of continuous strings</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b5-pointers-annotation-of-discontinuous-strings">B.5 Pointers: Annotation of discontinuous strings</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b6-pointers-annotation-of-media-files">B.6 Pointers: Annotation of media files</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b7-pointers-support-the-annotation-of-timestampstimelines">B.7 Pointers: Support the annotation of timestamps/timelines</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b8-pointers-standoff-annotation">B.8 Pointers: standoff annotation</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b9-generic-data-structures-for-linguistic-annotation-node--pointer">B.9 Generic data structures for linguistic annotation: node != pointer</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b10-generic-data-structures-for-linguistic-annotation-zero-nodes">B.10 Generic data structures for linguistic annotation: zero nodes</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b11-generic-data-structures-for-linguistic-annotation-edge-relation">B.11 Generic data structures for linguistic annotation: edge ('relation')</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b12-reified-representation-of-edges-annotation-relations">B.12 Reified representation of edges (annotation relations)</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b13-generic-data-structures-for-linguistic-annotation-graphs">B.13 Generic data structures for linguistic annotation: graphs</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b14-generic-data-structures-for-linguistic-annotation-annotations">B.14 Generic data structures for linguistic annotation: annotations</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b15-generic-data-structures-for-linguistic-annotation-annotation-space-tagset">B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b16-provenance-and-confidence">B.16 Provenance and confidence</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b17-concurrent-annotation">B.17 Concurrent annotation</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b18-sequence-of-annotation-units">B.18 Sequence of annotation units</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b19-annotation-values-plain-literals">B.19 annotation values: plain literals</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#b20-annotation-values-feature-structures">B.20 annotation values: feature structures</link>
+                        </para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+               <listitem>
+                  <para>
+                     <link xl:href="#c-levels-of-linguistic-analysis-units-of-annotation">C. Levels of linguistic analysis: units of annotation</link>
+                  </para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>
+                           <link xl:href="#c1-word-level-annotations-word-unit">C.1 Word-level annotations: word unit</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#c2-sentence-level-annotation-sentence-unit">C.2 Sentence-level annotation: sentence unit</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#c3-morphology-morphological-segments">C.3 morphology: morphological segments</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#c4-syntaxtext-structure-node-labelstypes">C.4 syntax/text structure: node labels/types</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#c5-semantics-node-labelstypes">C.5 semantics: node labels/types</link>
+                        </para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+               <listitem>
+                  <para>
+                     <link xl:href="#d-levels-of-linguistic-analysis-sequential-structure">D. Levels of linguistic analysis: sequential structure</link>
+                  </para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>
+                           <link xl:href="#d1-word-level-annotation-sequence-of-words">D.1 Word-level annotation: sequence of words</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#d2-sentence-level-annotation-sequence-of-sentences">D.2 Sentence-level annotation: sequence of sentences</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#d3-morphology-sequence-of-morphological-segments">D.3 Morphology: sequence of morphological segments</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#d4-syntax-discontinuous-multi-word-segments">D.4 Syntax: discontinuous multi-word segments</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#d5-syntaxtext-structure-sequence-of-elements-within-a-phrase">D.5 Syntax/text structure: sequence of elements within a phrase</link>
+                        </para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+               <listitem>
+                  <para>
+                     <link xl:href="#e-levels-of-linguistic-analysis-relational-structure">E. Levels of linguistic analysis: relational structure</link>
+                  </para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>
+                           <link xl:href="#e1-morphology-relations">E.1 Morphology: relations</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#e2-dependency-syntax">E.2 Dependency syntax</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#e3-phrase-structure-syntax-hierarchical-relations">E.3 Phrase structure syntax: hierarchical relations</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#e4-phrase-structure-syntax-other-relations">E.4 Phrase structure syntax: other relations</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#e5-semantics-relations">E.5 Semantics: relations</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#other-to-be-added">Other (to be added)</link>
+                        </para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+               <listitem>
+                  <para>
+                     <link xl:href="#f-data-structures-for-novel-applications">F. Data structures for novel applications</link>
+                  </para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>
+                           <link xl:href="#f1-intertextual-relations">F.1 Intertextual relations</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#f2-collation-and-alignment">F.2 Collation and alignment</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#f3-links-with-lexical-resources">F.3 Links with lexical resources</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#f4-dialog-annotation">F.4 Dialog annotation</link>
+                        </para>
+                     </listitem>
+                     <listitem>
+                        <para>
+                           <link xl:href="#other-please-add">Other (please add)</link>
+                        </para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+            </itemizedlist>
+         </section>
+         <section>
+            <title>A. LLOD compliancy</title>
+            <section>
+               <title>A.1 RDF serialization</title>
+               <itemizedlist>
+                  <listitem>
+                     <para>The vocabulary must foresee a serialization in RDF or any standardized RDF format (JSON-LD, RDF/XML, Turtle, ...)</para>
+                  </listitem>
+                  <listitem>
+                     <para>Trivially fulfulled by RDF vocabularies such as Web Annotation, but not by, say, ISO standards such as the Linguistic Annotation Framework (LAF), conventional TSV formats ("CoNLL") or XML formats (TEI).</para>
+                  </listitem>
+               </itemizedlist>
+               <para>Counter-example (https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-relation.html):</para>
+               <para>```
+&lt;relation resp="http://viaf.org/viaf/44335536/"
+ ref="http://purl.org/saws/ontology#isVariantOf"
+ active="http://www.ancientwisdoms.ac.uk/cts/urn:cts:greekLit:tlg3017.Syno298.sawsGrc01:divedition.divsection1.o14.a107"
+ passive="http://data.perseus.org/citations/urn:cts:greekLit:tlg0031.tlg002.perseus-grc1:9.35"/&gt;
+```</para>
+               <para>This example records a relationship, defined by the SAWS ontology, between a passage of text identified by a CTS URN, and a variant passage of text in the Perseus Digital Library, and assigns the identification of the relationship to a particular editor (all using resolvable URIs). This is a counter-example in the sense that the TEI does not support a (W3C- or otherwise) standardized way to encode RDF statements but introduces TEI-specific formalisms.</para>
+               <para>NIF: <computeroutput>+</computeroutput> (RDF)</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput> (RDF, preference for JSON-LD)</para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>SemAF: <computeroutput>-</computeroutput>
+               </para>
+            </section>
+            <section>
+               <title>A.2 Extent of standardization</title>
+               <para>Are candidate vocabularies standardized by a formal standardization body (e.g., ISO, W3C, etc., mark as <computeroutput>+</computeroutput>), community standards used by multiple providers (mark as <computeroutput>(+)</computeroutput>) or tool- or application-specific solutions (mark as <computeroutput>-</computeroutput>)?</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput> (regular W3C standard)</para>
+               <para>NIF: <computeroutput>(+)</computeroutput> (widely used community standard, and referred to in W3C standards)</para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (some usage, not standardized)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (this basically implements LAF)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SemAF: <computeroutput>+</computeroutput>
+               </para>
+            </section>
+            <section>
+               <title>A.3 Documentation</title>
+               <para>The vocabulary/standard should be</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>fully documented using public, freely accessible online documentation, mark as <computeroutput>+</computeroutput>, or</para>
+                  </listitem>
+                  <listitem>
+                     <para>fully documented using proprietary, internally accessible documentation, mark as <computeroutput>(+)</computeroutput>.</para>
+                  </listitem>
+                  <listitem>
+                     <para>If partially documented using public, freely accessible online documentation, mark as <computeroutput>(-)</computeroutput>.</para>
+                  </listitem>
+                  <listitem>
+                     <para>Otherwise, mark as <computeroutput>-</computeroutput>.</para>
+                  </listitem>
+               </itemizedlist>
+               <para>NIF: <computeroutput>+</computeroutput> (for NIF 2.0)</para>
+               <para>NIF 2.1: <computeroutput>(-)</computeroutput> (NIF 2.1 documentation does not properly reflect the latest advancements since NIF 2.0)</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>ISO standards (LAF, etc.) are usually proprietary. If internal copies or drafts are accessible, use <computeroutput>(+)</computeroutput> and describe how to access them. If 'only' supporting documentation (e.g., secondary literature such as scientific papers about the standard) are accessible, use <computeroutput>(-)</computeroutput>. If only the proprietary standard itself is accessible, without either secondary literature or drafts, use <computeroutput>-</computeroutput>.</para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (via https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf)</para>
+               <para>MAF: <computeroutput>+</computeroutput> (link tbc.)</para>
+               <para>SynAF: <computeroutput>-</computeroutput> (unless link/information provided)</para>
+               <para>SemAF: <computeroutput>-</computeroutput> (unless link/information provided)</para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (on-line documentation dated, more up-to-date documentation in Cimiano et al. 2020, but this is not open access)</para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (partially documented only)</para>
+            </section>
+            <section>
+               <title>A.4 IRI fragment identifiers for strings</title>
+               <para>A highly praised feature of NIF (in comparison to Web Annotation) is that it supports compact String URIs that can be interpreted in isolation (but whose information can [should] be made explicit in RDF statements).</para>
+               <para>Example:
+<computeroutput>http://example.com#hash_4_8_7049dd7875989b97e8568f5c0fd1f12b_favorite</computeroutput> (NIF String URI)
+<computeroutput>http://example.org/document/1#char=0,11</computeroutput> (RFC5147 String URI)</para>
+               <para>In NIF, this is part of the specification (<computeroutput>+</computeroutput>). In Web Annotation, this is possible, but not part of the standard, but only described in a <link xl:href="https://w3c.github.io/web-annotation/selector-note/">working note</link>, hence <computeroutput>(+)</computeroutput>. For a list of relevant standards for IRI fragment identifiers see https://en.wikipedia.org/wiki/Web<emphasis>annotation#Related</emphasis>specifications.</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput> (provides <emphasis>token</emphasis> identifiers, not string identifiers. surface string lost in the underlying CoNLL format)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(-)</computeroutput> (not specified, to be provided by complementary vocabulary, e.g., NIF or WA)</para>
+               <para>LAF: <computeroutput>-</computeroutput> (proprietary means of defining selectors)</para>
+            </section>
+            <section>
+               <title>A.5 Explicit selectors</title>
+               <para>Aside from string IRIs, it should be possible to decode their information (e.g., offset information) into RDF statements.</para>
+               <para>Example (NIF):
+```
+<link xl:href="http://example.org/document/1#char=0,11">http://example.org/document/1#char=0,11</link>
+ a nif:String ;
+ nif:isString "the content"^^xsd:string;
+ nif:beginIndex "0"^^xsd:nonNegativeInteger;
+ nif:endIndex "11"^^xsd:nonNegativeInteger;
+ nif:sourceUrl &lt;http://differentday.blogspot.com/2007<emphasis>01</emphasis>01_archive.html&gt;.
+```</para>
+               <para>Example (Web Annotation):</para>
+               <para>```
+[] a oa:ResourceSelection;
+     oa:hasSource <link xl:href="http://example.org/ebook1">http://example.org/ebook1</link> ;
+     oa:hasSelector [
+        a oa:TextPositionSelector ;
+        oa:start 412 ;
+        oa:end 795
+     ].
+```</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (recent publications recommend to rely on external vocabularies instead)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>Doesn't apply to LAF, etc.</para>
+            </section>
+            <section>
+               <title>A.6 Explicit context strings</title>
+               <para>In order to facilitate interpretability and robustness of string URIs (regardless of changes in underlying resource or differences in, say, Unicode normalization), the vocabulary should permit to provide explicit contexts that contain the text that a string IRI refers to (e.g., its offsets).</para>
+               <para>Example (NIF):
+```
+<link xl:href="http://example.org/document/1#char=0,21">http://example.org/document/1#char=0,21</link> 		# context object 
+ a nif:String , nif:Context ;
+ nif:isString "We talk about Xiamen."^^xsd:string;	# string value of context
+ nif:beginIndex "0"^^xsd:nonNegativeInteger;		# selector properties for context within source
+ nif:endIndex "21"^^xsd:nonNegativeInteger;
+ nif:sourceUrl &lt;http://differentday.blogspot.com/2007<emphasis>01</emphasis>01_archive.html&gt; .	# source URL</para>
+               <para>
+                  <link xl:href="http://example.org/document/1#char=14,20">http://example.org/document/1#char=14,20</link> a nif:String ;
+ nif:referenceContext <link xl:href="http://example.org/document/1#char=0,3680">http://example.org/document/1#char=0,3680</link> ;	# points to reference context
+ nif:anchorOf "Xiamen"^^xsd:string ;					# string value of annotation unit
+ nif:beginIndex "14"^^xsd:nonNegativeInteger ;				# selector properties for string within context
+ nif:endIndex "20"^^xsd:nonNegativeInteger ;
+ a nif:Word.
+```</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>-</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>Doesn't apply to LAF, etc.</para>
+            </section>
+            <section>
+               <title>A.7 API specifications for web services</title>
+               <para>In addition to modelling aspects, the vocabulary should provide API specifications for web services that perform linguistic annotation, e.g., POS tagging, or that provide access to and/or manipulation of data.</para>
+               <para>NIF: <computeroutput>+</computeroutput> (https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html)</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput> (https://www.w3.org/TR/annotation-protocol/)</para>
+               <para>None of the other vocabularies specify web service protocols.</para>
+               <para>For independent APIs, also cf. DTS: https://distributed-text-services.github.io/specifications/ (esp. for applications in the humanities)</para>
+            </section>
+            <section>
+               <title>A.8 Assign data categories</title>
+               <para>A vocabulary for linguistic annotation should either provide an exhaustive inventory of possible data categories (this is not possible, because more and novel annotation [schemes] keep emerging) or define how to link to a community-maintained repository of reference categories (this is the solution adopted in LAF and NIF).</para>
+               <para>A vocabulary can either provide its own properties (e.g. <computeroutput>nif:oliaLink</computeroutput>) or use standard RDF properties (<computeroutput>rdf:type</computeroutput>, etc.), but the strategy should be made explicit.</para>
+               <para>NIF: <computeroutput>(+)</computeroutput> (<computeroutput>nif:oliaLink</computeroutput>, pointing to <link xl:href="http://purl.org/olia/; for string annotations only; not for relational annotations">OLiA</link>
+               </para>
+               <para>Web Annotation: <computeroutput>(-)</computeroutput> (No reference vocabulary defined, but annotations can be defined as subclasses of OLiA classes)</para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (LAF and other ISO/TC37 standards: pointing to <link xl:href="http://www.isocat.org/">ISOCat</link>, no longer maintained, successor solutions are only emerging: <link xl:href="https://www.clarin.eu/ccr">CCR</link>, <link xl:href="http://www.datcatinfo.net/#/">DatCatInfo</link>)</para>
+               <para>MAF: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>SemAF: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (Publications and examples feature OLiA links, but only via <computeroutput>rdf:type</computeroutput> assignments; CoNLL-RDF is a NIF fragment, so, <computeroutput>nif:oliaLink</computeroutput> could be used)</para>
+               <para>Ligt: <computeroutput>(+)</computeroutput> (Not specified, but designed as a NIF fragment, so, <computeroutput>nif:oliaLink</computeroutput> could be used)</para>
+            </section>
+            <section>
+               <title>A.9 Compatible with Web Annotation vocabulary</title>
+               <para>Web Annotation is an important standard, and the only actual W3C standard for RDF-based annotations on the web. Compatibility with Web Annotation is thus a requirement.</para>
+               <para>If a vocabulary</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>builds and refines Web Annotation data structures, mark as <computeroutput>+</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>is transformable into / can be used in combination with Web Annotation, but is redundant (i.e., provides its own vocabulary for aspects covered by Web Annotation), mark as <computeroutput>(+)</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>can be used for some (which?) use cases in combination with Web Annotation, but has incompatible conceptualizations, mark as <computeroutput>(-)</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>otherwise, <computeroutput>-</computeroutput>
+                     </para>
+                  </listitem>
+               </itemizedlist>
+               <para>NIF: <computeroutput>(+)</computeroutput> (Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets)</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (A partial reconstruction of LAF within WA has been described by Verspoor et al. 2012, but this does not seem to have been adopted in subsequent research nor evaluated by any third party.)</para>
+               <para>MAF: <computeroutput>(+)</computeroutput> (not checked in detail, but cf. LAF)</para>
+               <para>SemAF: <computeroutput>(+)</computeroutput>  (not checked in detail, but cf. LAF)</para>
+               <para>SynAF: <computeroutput>(+)</computeroutput>  (not checked in detail, but cf. LAF)</para>
+            </section>
+            <section>
+               <title>A.10 Compatible with NIF 2.0 core vocabulary</title>
+               <para>NIF has an indepndent user and developer community that should be involved in the results of any harmonization effort, compatibility with NIF is thus a requirement.</para>
+               <para>If a vocabulary</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>builds and refines NIF data structures, mark as <computeroutput>+</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>is transformable into / can be used in combination with NIF, but is redundant (i.e., provides its own vocabulary for aspects covered by NIF), mark as <computeroutput>(+)</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>can be used for some (which?) use cases in combination with NIF, but has incompatible conceptualizations, mark as <computeroutput>(-)</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>otherwise, <computeroutput>-</computeroutput>
+                     </para>
+                  </listitem>
+               </itemizedlist>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>(-)</computeroutput> (conversion restricted to types of annotation supported by NIF, potential loss of information, e.g., distinction between target and annotation, resp., body and annotation is unclear)</para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput> (extends NIF vocabulary with data structures for one-word-per-line annotations, e.g., CoNLL, SketchEngine formats, see <link xl:href="https://github.com/acoli-repo/conll-rdf/">here</link>; note the <link xl:href="https://github.com/acoli-repo/conll-rdf/blob/master/examples/tree-example.sh">extension for the encoding of trees</link> by means of <link xl:href="http://purl.org/powla/powla.owl">POWLA</link>)</para>
+               <para>Ligt: <computeroutput>+</computeroutput> (extends NIF vocabulary with specifications for morphology (interlinear glossed text); still under development, see <link xl:href="https://github.com/acoli-repo/ligt">here</link>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>-</computeroutput> (NIF systematically conflates LAF data structures, see A.11)</para>
+            </section>
+            <section>
+               <title>A.11 Compatible with ISO standards</title>
+               <para>Much community work on standardization has been going into a standardization process conducted within ISO TC37. Unfortunately, documentation is partially available only, so we consider compliancy with <link xl:href="https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf">LAF</link> only, here. For application-specific substandards of LAF (MAF, SynAF, SemAF), cf. discussion below.</para>
+               <para>ISO standards by themselves are not directly compatible with NIF or Web Annotation as long as they are lacking an RDF serialization. A LAF serialization has been the basis for developing <link xl:href="http://purl.org/powla/powla.owl">POWLA</link>) that can be used in combination with either NIF or Web Annotation.</para>
+               <para>NIF: <computeroutput>-</computeroutput> (no generic data structures for linguistic annotation; conflates regions and nodes, see below)</para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput> (regions ~ targets, nodes ~ annotation, annotation ~ body; but no linguistic data structures, combination has been explored by <link xl:href="https://www.aclweb.org/anthology/W12-3610.pdf">Verspoor et al. (2012)</link>.</para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput> (only a specific subset, possibly SynAF)</para>
+               <para>Ligt: <computeroutput>-</computeroutput> (only a specific subset, possibly MAF)</para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SemAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>+</computeroutput>
+               </para>
+            </section>
+         </section>
+         <section>
+            <title>B. Expressiveness</title>
+            <para>This mostly refers to the capability of providing 'generic' data structures as defined by <link xl:href="https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf">ISO 24612-2012 (LAF)</link>: generic linguistic data structures from which annotation-specific datastructures can be derived. These are</para>
+            <itemizedlist>
+               <listitem>
+                  <para>pointers to primary data ("media")</para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>Anchor (pointer to a piece of primary data)</para>
+                     </listitem>
+                     <listitem>
+                        <para>Region (group of anchors that define a markable that can be annotated)</para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+               <listitem>
+                  <para>units of annotation ("graph")</para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>node (annotatable element linked with a region)</para>
+                     </listitem>
+                     <listitem>
+                        <para>edge (relation from one or multiple nodes to one or multiple nodes)</para>
+                     </listitem>
+                     <listitem>
+                        <para>graph (collection of nodes and edges)</para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+               <listitem>
+                  <para>annotations</para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>annotation (linguistic information attached to any node or edge)</para>
+                     </listitem>
+                     <listitem>
+                        <para>annotation space (groups together annotations of the same type, say, POS)</para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+            </itemizedlist>
+            <para>Note that it is not required here to provide an RDF encoding, but 'any' solution.</para>
+            <para>Web Annotation does not define any specifically 'linguistic' data structures. It does provide pointers ('targets') and an abstract <computeroutput>oa:Annotation</computeroutput> class.</para>
+            <para>NIF defines:</para>
+            <itemizedlist>
+               <listitem>
+                  <para>String (for the annotation of strings)</para>
+                  <itemizedlist>
+                     <listitem>
+                        <para>Word</para>
+                     </listitem>
+                     <listitem>
+                        <para>Sentence</para>
+                     </listitem>
+                     <listitem>
+                        <para>Phrase</para>
+                     </listitem>
+                     <listitem>
+                        <para>Title</para>
+                     </listitem>
+                     <listitem>
+                        <para>Paragraph</para>
+                     </listitem>
+                  </itemizedlist>
+               </listitem>
+               <listitem>
+                  <para>AnnotationUnit (for annotations that need to be distinguished from a particular way, note that these must not be any of the String subclasses)</para>
+               </listitem>
+            </itemizedlist>
+            <para>Generic linguistic data structures (as in LAF) are missing. For specific levels of description (e.g., morphology), see below.</para>
+            <section>
+               <title>B.1 Pointers to primary data</title>
+               <para>In RDF vocabularies either by IRI fragment identifiers or explicit RDF statements (and vocabulary for that).</para>
+               <para>Examples for IRI fragment identifiers as pointers:</para>
+               <para>
+                  <computeroutput>http://example.com/text.txt#char=100</computeroutput> (RFC 5147 character offset = LAF anchor)
+<computeroutput>http://example.com/text.txt#char=100,105</computeroutput> (RFC 5147 string URI = LAF region)</para>
+               <para>The default mechanism to define pointers in Web Annotation is by means of selectors that use application-specific information to address elements of a web document using explicit RDF statements.</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (pointers to tokens, not primary data)</para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (pointers to data structures, not primary data)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (offset-based pointers possible, last publications recommend to use external vocabularies)</para>
+               <para>LAF: <computeroutput>+</computeroutput> (XPointers)</para>
+               <para>MAF: <computeroutput>+</computeroutput> (from LAF)</para>
+               <para>SemAF: <computeroutput>+</computeroutput> (from LAF)</para>
+               <para>SynAF: <computeroutput>+</computeroutput> (from LAF)</para>
+            </section>
+            <section>
+               <title>B.2 Pointers: Vocabulary for explicit references</title>
+               <para>Provide (optional) RDF statements to explicate pointer information (e.g., offsets).</para>
+               <para>Example (NIF):</para>
+               <para>```
+<link xl:href="http://example.org/document/1#char=14,20">http://example.org/document/1#char=14,20</link>
+ nif:beginIndex "14"^^xsd:nonNegativeInteger ;
+ nif:endIndex "20"^^xsd:nonNegativeInteger .
+```</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (offset-based pointers possible, last publications recommend to use external vocabularies)</para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>-</computeroutput> (no RDF statements)</para>
+            </section>
+            <section>
+               <title>B.3 Pointers: User-provided selectors</title>
+               <para>Allow users to define application-specific pointers.</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>, provides the class <computeroutput>oa:Selector</computeroutput>. For different media, users can provide selector subclasses that encode the information an appication needs to identify the annotated element.</para>
+               <para>NIF: <computeroutput>-</computeroutput> (would be considered out of scope)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (in combination with Web Annotation)</para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(-)</computeroutput> (actually, this is hard to tell, technically, this would be possible, but there don't seem to be documented examples)</para>
+            </section>
+            <section>
+               <title>B.4 Pointers: Support the annotation of continuous strings</title>
+               <para>represent continuous multi-word segments, necessary for syntactic phrases, semantic annotations</para>
+               <para>Example (basic phrase structure syntax)</para>
+               <para>```
+[NP ten books]
+```</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SemAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>+</computeroutput>
+               </para>
+            </section>
+            <section>
+               <title>B.5 Pointers: Annotation of discontinuous strings</title>
+               <para>If one wants to "highlight" all entities (or particular words/phrases/strings), he/she would need to annotate each entity mention (word/phrases/strings).</para>
+               <para>Example:
+<computeroutput>Diego Maradona is from Argentina.</computeroutput>
+               </para>
+               <para>```
+ext:offset<emphasis>0</emphasis>14 -&gt; Diego Maradona
+ext:offset<emphasis>23</emphasis>32 -&gt; Argentina
+```</para>
+               <para>NIF: <computeroutput>-</computeroutput> (annotations such as <computeroutput>ext:offset_0_14_23_32</computeroutput> are not considered nor supported)</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput> (multiple selectors can be combined into an aggregate selector)</para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (not natively, but in combination with POWLA)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (a terminal is offset-defined, so it apparently has to be a continuous string, but nonterminals can aggregate discontinuous sequences of terminals)</para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (in principle, discontinuous aggregates could exist, but there are no examples for that nor any model in current IGT annotation)</para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (the existence of discontinuous anchors needs to be confirmed, but nodes can aggregate other nodes regardless of their position)</para>
+               <para>MAF, SemAF, SynAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.6 Pointers: Annotation of media files</title>
+               <para>Annotation of non-textual data, e.g., audio, video, images.</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput> (core feature)</para>
+               <para>NIF: <computeroutput>-</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(-)</computeroutput> (tbc.)</para>
+            </section>
+            <section>
+               <title>B.7 Pointers: Support the annotation of timestamps/timelines</title>
+               <para>For multi-media annotation, timeline-based annotation is the primary annotation strategy adopted by tools such as <link xl:href="https://tla.mpi.nl/tools/tla-tools/elan/">ELAN</link> and <link xl:href="https://exmaralda.org/en/about-exmaralda/">Exmaralda</link>. Here, textual data is the value (body) of an annotation, the timeline is correlated with one or multiple mediafiles, but the mediafile is not directly the target of the annotation.</para>
+               <para>Example and motivation: see https://www.exmaralda.org/files/SFB_AzM62.pdf (Fig. 2)</para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput> (users may provide a specialized selector for such data)</para>
+               <para>NIF: <computeroutput>-</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (if combined with Web Annotation)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (tbc.; CC: I'm pretty sure this has been addressed)</para>
+               <para>MAF, SynAF, SemAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.8 Pointers: standoff annotation</title>
+               <para>Vocabulary should be able to annotate content residing in a separate file or resource.</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>(+)</computeroutput> (no examples known)</para>
+               <para>MAF, SemAF, SynAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.9 Generic data structures for linguistic annotation: node != pointer</title>
+               <para>
+                  <link xl:href="https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf">ISO 24612-2012</link> pointers are distinguished from units of annotation. Conceptually, it is important that pointers and units of annotations are (or: can be) distinguished, because the same string may have multiple, independent annotations.</para>
+               <para>Example:</para>
+               <para>```
+[S [VF [NP [NE Peter ] ] ] [LK [V war ] ] [MF [ADVX [ADV nicht] [ADV zuhause] ] ] ]
+```</para>
+               <para>German, 'Peter wasn't home', example inspired by <link xl:href="http://www.sfs.uni-tuebingen.de/en/ascl/resources/corpora/tueba-dz.html">TüBa-D/Z corpus</link>
+               </para>
+               <para>```
+VF -&gt; Peter (Vorfeld, syntactic position)
+NP -&gt; Peter (Noun Phrase, constituent at VF position)
+NE -&gt; Peter (Named Entity that constitutes the NP)
+```</para>
+               <para>These are co-extensional, but their hierarchical organization (in the annotation) is meaningful and must be preserved even though they refer to the same string value.</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput> (pointer = target, node = annotation or body -- depending on interpretation)</para>
+               <para>NIF: <computeroutput>-</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (in combination with POWLA)</para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (unclear)</para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF, SemAF, SynAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.10 Generic data structures for linguistic annotation: zero nodes</title>
+               <para>Support the annotation of zero elements, e.g., elements of syntactic analysis that are not overtly realized, e.g., traces or zero anaphors.</para>
+               <para>Note that a zero element can have a position in the text (and can be annotated as an empty string, then), but only if its position can be inferred, e.g., by substitution.</para>
+               <para>Example (elision):
+```
+Peter was looking forward to it. Mary was [0], too.
+Peter was looking forward to it. Mary was [looking forward to it], too.
+```</para>
+               <para>However, implicit semantic roles that are not resolvable against the context do not have a position in the text:</para>
+               <para>Example:
+```
+[AGENT Rome] withdrew [SOURCE from Britain] [TIME around 409 CE].
+```</para>
+               <para>The frame (<link xl:href="https://framenet2.icsi.berkeley.edu/fnReports/data/frameIndex.xml?frame=Removing">withdraw</link>) defines two core arguments not realized in the sentence, THEME (object that changes location, here: troops), and CAUSE (here: to defend continental territories of the Roman Empire). These have no position in the text, but <link xl:href="https://www.aclweb.org/anthology/P10-1160.pdf">can be annotated</link>.</para>
+               <para>Full-fledged zero annotation must thus permit both annotations of zero strings that are attached to a particular position in the text and zero annotations that independent from any string realization (but are indirectly evoked, here, by the verb).</para>
+               <para>For textual data, the vocabulary should thus</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>support annotations that exist independently from their string seriaization: mark as <computeroutput>+</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>support the annotation of empty strings: mark as <computeroutput>(+)</computeroutput> (with parentheses)</para>
+                  </listitem>
+                  <listitem>
+                     <para>require the annotation target to be an non-empty string: mark as <computeroutput>-</computeroutput>.</para>
+                  </listitem>
+               </itemizedlist>
+               <para>NIF: <computeroutput>(+)</computeroutput> (the default encoding for annotations in NIF is by subclasses of <computeroutput>nif:String</computeroutput>)</para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput> (Web annotation requires some target.)</para>
+               <para>POWLA: <computeroutput>+</computeroutput> (from LAF)</para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (for zero tokens in underlying CoNLL format)</para>
+               <para>MAF, SemAF, SynAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.11 Generic data structures for linguistic annotation: edge ('relation')</title>
+               <para>
+                  <link xl:href="https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf">ISO 24612-2012</link> edge is a relation from one or multiple nodes to one or multiple nodes. Edges are, for example, syntactic dependencies. The vocabulary should provide a way to mark an RDF statement as being a edge/relation in the sense of LAF, e.g., a property or class that annotation-specific edges can provide sub-classes/-properties for.</para>
+               <para>Example (<link xl:href="http://purl.org/powla/powla.owl">POWLA</link>):
+<computeroutput>powla:Relation</computeroutput> (concept) with properties <computeroutput>powla:isSourceOf</computeroutput> and <computeroutput>powla:isTargetOf</computeroutput>
+               </para>
+               <para>No explicit data structures for edges in NIF nor Web Annotation.</para>
+               <para>NIF: <computeroutput>-</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (restricted to syntactic dependencies and semantic roles)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF: tbc.</para>
+               <para>SemAF: <computeroutput>+</computeroutput> (tbc: restricted to certain relation types)</para>
+               <para>SynAF: <computeroutput>+</computeroutput> (part of the old TIGER format, SynAF is marketed as TIGER2, so, it should keep that)</para>
+               <section>
+                  <title>B.11.a Non-reified representation of edges</title>
+                  <para>It should be possible to encode edges with a single RDF statement (if provider decides not provide metadata, etc.).</para>
+                  <para>Example (<link xl:href="http://purl.org/powla/powla.owl">POWLA</link>; BUT: restricted to hierachical reations):
+<computeroutput>powla:hasParent</computeroutput> resp. <computeroutput>powla:hasChild</computeroutput>
+                  </para>
+                  <para>NIF: <computeroutput>(-)</computeroutput> (<computeroutput>nif:subStringOf</computeroutput> could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. <link xl:href="http://stanford.nlp2rdf.aksw.org/stanfordcorenlpn?f=text&amp;i=This+is+a+test.&amp;t=direct">NIF Stanford Core demo</link>)</para>
+                  <para>Web Annotation: <computeroutput>-</computeroutput>
+                  </para>
+                  <para>POWLA: <computeroutput>(+)</computeroutput> (for hierarchical relations only)</para>
+                  <para>Ligt: <computeroutput>-</computeroutput>
+                  </para>
+                  <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (for semantic roles only)</para>
+                  <para>LAF, MAF, SemAF, SynAF: not applicable, no RDF</para>
+               </section>
+            </section>
+            <section>
+               <title>B.12 Reified representation of edges (annotation relations)</title>
+               <para>For an edge (relation), it must be possible to annotate it with additional data, e.g., linguistic data categories. The vocabulary should support a reified view on, say, dependency relations.</para>
+               <para>Example  (<link xl:href="http://purl.org/powla/powla.owl">POWLA</link>):
+```
+:relation a powla:Relation, powla:DominanceRelation;
+ a olia:SyntacticAdjunct;
+ powla:hasSource :someElement; powla:hasTarget :someOtherElement.
+```</para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>NIF: <computeroutput>-</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput> (only in combination with POWLA)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(+)</computeroutput> ("reification" is not directly applicable to non-RDF data)</para>
+            </section>
+            <section>
+               <title>B.13 Generic data structures for linguistic annotation: graphs</title>
+               <para>In LAF, a graph a is a collection of nodes and edges. In RDF, this corresponds to an RDF graph (often representing the document that a particular set of RDF statements originates from). We do not require explicit data structures for graphs beyond that (do we?). A vocabulary that provides explicit data structures would be <computeroutput>+</computeroutput>, any other RDF vocabulary would be <computeroutput>(+)</computeroutput>, non-RDF vocabularies without explicit data structures would be <computeroutput>-</computeroutput>.</para>
+               <para>NIF: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>MAF, SemAF, SynAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.14 Generic data structures for linguistic annotation: annotations</title>
+               <para>
+                  <link xl:href="https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf">ISO 24612-2012</link> defines generic linguistic data structures from which annotation-specific datastructures can be derived. These are</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>pointers to primary data ("media")</para>
+                  </listitem>
+                  <listitem>
+                     <para>units of annotation ("graph")</para>
+                  </listitem>
+                  <listitem>
+                     <para>annotations</para>
+                     <itemizedlist>
+                        <listitem>
+                           <para>annotation (linguistic information attached to any node or edge)</para>
+                        </listitem>
+                        <listitem>
+                           <para>annotation space (groups together annotations of the same type, say, POS)</para>
+                        </listitem>
+                     </itemizedlist>
+                  </listitem>
+               </itemizedlist>
+               <para>The vocabulary should provide a designated class for linguistic annotations that different application can create application-specific subclasses for. In Web Annotation, this would be either <computeroutput>oa:Annotation</computeroutput> or a body (depending on interpretation). In NIF, such an element is missing. For annotations of a particular string, this function is taken over by <computeroutput>nif:String</computeroutput>, for more complex constellations, <computeroutput>nif:AnnotationUnit</computeroutput> can be used, but is not the default way of modelling.</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>NIF: <computeroutput>(-)</computeroutput> (<computeroutput>nif:String</computeroutput>), resp. <computeroutput>(+)</computeroutput> (<computeroutput>nif:AnnotationUnit</computeroutput>, not the default encoding, though)</para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (tbc)</para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (not created by default)</para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (tbc)</para>
+               <para>MAF, SemAF, SynAF: tbc</para>
+            </section>
+            <section>
+               <title>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</title>
+               <para>
+                  <link xl:href="https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf">ISO 24612-2012</link> defines generic linguistic data structures from which annotation-specific datastructures can be derived. These are</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>pointers to primary data ("media")</para>
+                  </listitem>
+                  <listitem>
+                     <para>units of annotation ("graph")</para>
+                  </listitem>
+                  <listitem>
+                     <para>annotations</para>
+                     <itemizedlist>
+                        <listitem>
+                           <para>annotation (linguistic information attached to any node or edge)</para>
+                        </listitem>
+                        <listitem>
+                           <para>annotation space (groups together annotations of the same type, say, POS)</para>
+                        </listitem>
+                     </itemizedlist>
+                  </listitem>
+               </itemizedlist>
+               <para>The vocabulary should provide a standard way to assign annotations a particular type or class. This corresponds to user-provided subclasses of (the abstract) <computeroutput>oa:Annotation</computeroutput> class in Web Annotation. In NIF, this could be treated as part of provenance metadata, but a designated property seems to be missing.</para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>NIF: <computeroutput>(+)</computeroutput> (via OLiA)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (via OLiA)</para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (via OLiA)</para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (no example known)</para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF, SemAF, SynAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.16 Provenance and confidence</title>
+               <para>The vocabulary should provide a way to assert provenance (e.g., creator, tools involved, other sources), confidence (e.g. a confidence score or confidence level) and related metadata about annotations.</para>
+               <para>In particular, it is important</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>to be able to express <link xl:href="https://github.com/ld4lt/linguistic-annotation/issues/3">what person(s) or organization(s) is (are) responsible</link> asserting the claim behind a given linguistic annotation, and</para>
+                  </listitem>
+                  <listitem>
+                     <para>to express a level of confidence in an annotation; this is a <link xl:href="https://github.com/ld4lt/linguistic-annotation/issues/1">common need for linguistic annotations</link>
+                     </para>
+                  </listitem>
+               </itemizedlist>
+               <para>If a vocabulary is capable to</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>assert provenance (etc.) about (annotations of) nodes and edges, mark as <computeroutput>+</computeroutput>, or</para>
+                  </listitem>
+                  <listitem>
+                     <para>assert provenance (etc.) about (annotatios of) nodes, mark as <computeroutput>(+)</computeroutput>.</para>
+                  </listitem>
+                  <listitem>
+                     <para>If it can be complemented with an external RDF vocabulary to assert provenance (etc.), mark as <computeroutput>(-)</computeroutput>.</para>
+                  </listitem>
+                  <listitem>
+                     <para>Otherwise, mark as <computeroutput>-</computeroutput>.</para>
+                  </listitem>
+               </itemizedlist>
+               <para>NIF 2.1 defines <computeroutput>nif:AnnotationUnit</computeroutput> which can use used to distinguish annotations comming from different NLP tools on same strings (same offsets).</para>
+               <para>Web Annotation does not prescribe a reference vocabulary for provenance, but can be combined with, say, <link xl:href="https://www.w3.org/TR/prov-o/">PROV-O</link>.</para>
+               <para>NIF: <computeroutput>(-)</computeroutput> (NIF 2.0)</para>
+               <para>NIF 2.1: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>(-)</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>-</computeroutput> (no RDF extension possible)</para>
+               <para>POWLA: <computeroutput>(-)</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>(-)</computeroutput>
+               </para>
+            </section>
+            <section>
+               <title>B.17 Concurrent annotation</title>
+               <para>It should be possible to provide alternative, and distinct annotations of the same phenomenon with different provenance, e.g., for combining entity linking services or for comparing the output of different parsers.</para>
+               <para>In addition to provenance, this requires to identify the "annotation space" (LAF terminology).</para>
+               <para>Example (two alternative parses of the same sentence):
+'He saw the man with the telescope.'</para>
+               <para>```
+(S (NP He)             # high PP attachment, tool A
+   (VP saw
+       (NP the man)
+       (PP with the telescope)))</para>
+               <para>(S (NP He)             # low PP attachment, tool B
+   (VP saw
+       (NP the man
+           (PP with the telescope)))
+```</para>
+               <para>For TSV ("CoNLL") annotations, a file with multiple annotations can be created with <link xl:href="https://github.com/acoli-repo/conll">CoNLL-Merge</link>:</para>
+               <para>```
+ # WORD     PARSE-A         PARSE-B
+He         (S (NP *)       (S NP *)
+saw           (VP *           (VP *
+the               (NP *           (NP *
+man                   *)              *              # difference!
+with              (PP *               (PP *
+the                   *                   *
+telescope             *)))                *))))      # difference!
+```</para>
+               <para>Real-world examples: concurrent annotations of Brown corpus (<link xl:href="https://www.grsampson.net/RSue.html">Susanne</link>, <link xl:href="https://catalog.ldc.upenn.edu/LDC2019T05">Penn</link>), concurrent annotations of WSJ corpus (<link xl:href="https://catalog.ldc.upenn.edu/LDC2019T05">Penn</link>, <link xl:href="https://catalog.ldc.upenn.edu/ldc2013t19">OntoNotes</link>).</para>
+               <para>NIF: <computeroutput>-</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (different properties in different columns, controlled by the user)</para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (no example known)</para>
+               <para>MAF, SemAF, SynAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.18 Sequence of annotation units</title>
+               <para>An annotation vocabulary should allow to encode the sequence of annotation units of the same kind (words, sentences, ...), either by enumeration or by explicit properties.</para>
+               <para>Example (enumeration):
+<computeroutput>Diego Maradona is from Argentina.</computeroutput>
+               </para>
+               <para>```
+ext:offset<emphasis>0</emphasis>5 a nif:Word ; "Diego"
+  nif:anchorOf "Diego" ;
+  nif:enumeration "1" .</para>
+               <para>ext:offset<emphasis>6</emphasis>14 a nif:Word ; -&gt; "Maradona"
+  nif:enum "Maradona" .
+  nif:enumeration "2" ;
+```</para>
+               <para>Example (<computeroutput>nif:nextWord</computeroutput> property):</para>
+               <para>```
+ext:offset<emphasis>0</emphasis>5 nif:nextWord ext:offset<emphasis>6</emphasis>14
+```</para>
+               <para>Example (<computeroutput>rdf:List</computeroutput>):</para>
+               <para>```
+( ext:offset<emphasis>0</emphasis>5 ext:offset<emphasis>6</emphasis>14 ) a rdf:List .
+```</para>
+               <para>The different encoding possibilities can be transformed into each other. E.g., enumeration information (with indices) can be inferred from relations between words within a sentence, e.g., counting all <computeroutput>nif:nextWord</computeroutput> before a particular word.</para>
+               <para>To facilitate encoding, a vocabulary should specify which (if any) strategy is recommended. In addition to marking whether a vocabulary provides sequence annotation vocabulary (<computeroutput>+</computeroutput>, <computeroutput>-</computeroutput>), mark the strategy.</para>
+               <para>NIF: <computeroutput>(+)</computeroutput> (only for selected annotation units, e.g., <computeroutput>nif:nextWord</computeroutput>, <computeroutput>nif:nextSentence</computeroutput>)</para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>(+)</computeroutput> (for native annotation units)</para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (for native CoNLL-RDF annotation units)</para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF, SynAF, SemAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.19 annotation values: plain literals</title>
+               <para>The vocabulary should support annotation (annotation value/body) with plain literals, e.g., strings.</para>
+               <para>Example:
+```
+:some<emphasis>region</emphasis>uri nif:lemma "tree" .
+```</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF, SynAF, SemAF: tbc.</para>
+            </section>
+            <section>
+               <title>B.20 annotation values: feature structures</title>
+               <para>The vocabulary should support annotation (annotation value/body) with feature structures, i.e., root nodes of directed (acyclic) graphs. In RDF, this requirement can be reformulated as permitting RDF resources (URIs) as annotations.</para>
+               <para>Example:
+```
+:some<emphasis>region</emphasis>uri nif:oliaLink penn:NN.
+```</para>
+               <para>NIF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput> (e.g., using OLiA)</para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (can be represented, but are not created by default conversion)</para>
+               <para>Ligt: <computeroutput>(+)</computeroutput> (no example known)</para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>+</computeroutput> (tbc)</para>
+               <para>SynAF: <computeroutput>+</computeroutput> (tbc)</para>
+               <para>SemAF: <computeroutput>+</computeroutput>
+               </para>
+            </section>
+         </section>
+         <section>
+            <title>C. Levels of linguistic analysis: units of annotation</title>
+            <para>For a particular level of linguistic analysis, the vocabulary should</para>
+            <itemizedlist>
+               <listitem>
+                  <para>define (<computeroutput>+</computeroutput>) or address (<computeroutput>(+)</computeroutput>) the relevant units of annotation, and</para>
+               </listitem>
+               <listitem>
+                  <para>permit to navigate among units of annotation (e.g., retrieving the next annotation of the same kind)</para>
+               </listitem>
+            </itemizedlist>
+            <section>
+               <title>C.1 Word-level annotations: word unit</title>
+               <para>The vocabulary must support the annotation of individual words (tokens), e.g., for entity linking or part-of-speech tagging:</para>
+               <itemizedlist>
+                  <listitem>
+                     <para>If it provides a concept for words or tokens, mark as <computeroutput>+</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>If it can address/express words or tokens, but does not provide a designated concept, mark as <computeroutput>(+)</computeroutput>
+                     </para>
+                  </listitem>
+                  <listitem>
+                     <para>If it does not allow to annotate words, mark as <computeroutput>-</computeroutput>.</para>
+                  </listitem>
+               </itemizedlist>
+               <para>Example: part-of-speech annotation</para>
+               <para>```
+book/NN
+```</para>
+               <para>NIF: <computeroutput>+</computeroutput> (<computeroutput>nif:Word</computeroutput>)</para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput> (no designated concept)</para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput> (<computeroutput>nif:Word</computeroutput>)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (<computeroutput>powla:Terminal</computeroutput>, but can be sub-token)</para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SemAF: <computeroutput>+</computeroutput>
+               </para>
+            </section>
+            <section>
+               <title>C.2 Sentence-level annotation: sentence unit</title>
+               <para>NIF: <computeroutput>+</computeroutput> (<computeroutput>nif:Sentence</computeroutput>)</para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput> (no explicit data structure, but can be added)</para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput> (<computeroutput>nif:Sentence</computeroutput>)</para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (<computeroutput>powla:Root</computeroutput>, but this doesn't have to be sentential)</para>
+               <para>LAF: <computeroutput>(-)</computeroutput> (tbc.)</para>
+               <para>MAF: tbc.</para>
+               <para>SynAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SemAF: <computeroutput>+</computeroutput> (tbc.)</para>
+            </section>
+            <section>
+               <title>C.3 morphology: morphological segments</title>
+               <para>segment a word into its parts, annotate parts individually, required for interlinear glossed text</para>
+               <para>Example (interlinear glossed text):</para>
+               <para>```
+Bücher
+Buch -"er
+book -pl
+'books'
+```</para>
+               <para>Example:
+<computeroutput>cats</computeroutput> = <computeroutput>cat</computeroutput> + <computeroutput>s</computeroutput>
+```
+ext:offset<emphasis>0</emphasis>4 -&gt; cats</para>
+               <para>=</para>
+               <para>ext:offset<emphasis>0</emphasis>3 -&gt; cat
+ext:offset<emphasis>3</emphasis>4 -&gt; s
+```</para>
+               <para>Not addressed by NIF, neither WA.</para>
+               <para>NIF: <computeroutput>(-)</computeroutput> (no designated vocabulary, can be accessed as substrings, but not in all cases.)</para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput> (no designated vocabulary, but can be added)</para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (no designated vocabulary, but can be modelled as segments)</para>
+               <para>MAF: <computeroutput>+</computeroutput> (tbc.)</para>
+               <para>SynAF: <computeroutput>-</computeroutput> (tbc)</para>
+               <para>SemAF: tbc</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (no designated vocabulary, but can be added)</para>
+               <para>A candidate vocabulary to relate with is the OntoLex Morphology module:  https://www.w3.org/community/ontolex/wiki/Morphology.
+The interface between morphological dictionary and corpus has not been defined yet.</para>
+            </section>
+            <section>
+               <title>C.4 syntax/text structure: node labels/types</title>
+               <para>The vocabulary should provide (or refer to) an inventory of syntactic categories, e.g., phrase. Note that this must be extensible to accomodate novel types of annotation.</para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput> (via user-provided subclasses of <computeroutput>oa:Annotation</computeroutput>)</para>
+               <para>NIF: <computeroutput>(+)</computeroutput> (predefined datatypes <computeroutput>nif:Word</computeroutput>, <computeroutput>nif:Phrase</computeroutput>, <computeroutput>nif:Paragraph</computeroutput>, etc.; but note that these do not describe nodes in the sense of LAF, but regions)</para>
+               <para>In addition, NIF allows to use <computeroutput>nif:oliaLink</computeroutput> to refer to an external terminology base, here <link xl:href="http://purl.org/olia">OLiA</link>. An alternative to OLiA is the <link xl:href="https://www.clarin.eu/ccr">CLARIN Concept Registry</link>, but note that it is extensible only by national CLARIN representatives whereas OLiA is an <link xl:href="https://github.com/acoli-repo/olia">open source project on GitHub</link>. AFAIK, NIF uses <computeroutput>nif:oliaLink</computeroutput> for part of speech information only, so this is partial solution, again, hence, <computeroutput>(+)</computeroutput>.</para>
+               <para>POWLA: <computeroutput>+</computeroutput> (using an external vocabulary, OLiA)</para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (phrase structures can only be expressed in combination with POWLA)</para>
+               <para>Ligt: <computeroutput>-</computeroutput> (no examples for phrase-level annotations)</para>
+               <para>LAF: <computeroutput>+</computeroutput> (ISOcat)</para>
+               <para>SynAF: <computeroutput>(+)</computeroutput> (ISOcat, for syntax, but hard-wired data structures only)</para>
+               <para>MAF: <computeroutput>-</computeroutput> (no syntax nodes)</para>
+               <para>SemAF: <computeroutput>(+)</computeroutput> (ISOcat, for text/discourse, but hard-wired data structures only)</para>
+            </section>
+            <section>
+               <title>C.5 semantics: node labels/types</title>
+               <para>Similar as for syntax/text structure, details to be determined from SemAF, <link xl:href="http://nerd.eurecom.fr/ontology">NERD</link> (for named entities), <link xl:href="https://github.com/globalwordnet/ili">GlobalWordNet Interlingual Index</link> (for word senses), etc.</para>
+               <para>This requires a very rich and extensible inventory of data categories, so better as an external resource. Again, <link xl:href="http://purl.org/olia">OLiA</link> and the <link xl:href="http://www.acoli.informatik.uni-frankfurt.de/resources/discourse/">OLiA Discourse Extensions</link> are a candidate resources here, but note that this would require extensions wrt. lexical semantics.</para>
+               <para>NIF: <computeroutput>(-)</computeroutput>. NIF supports entity linking, but no other form of semantic annotation, hence <computeroutput>(-)</computeroutput>.</para>
+               <para>Web Annotation: <computeroutput>(-)</computeroutput>. Web Annotation is widely used for entity linking, but it does not provide a designated vocabulary for entities, hence <computeroutput>(-)</computeroutput>.</para>
+               <para>POWLA: <computeroutput>+</computeroutput> (using an external vocabulary, OLiA)</para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (can be created from CoNLL-RDF data)</para>
+               <para>Ligt: <computeroutput>-</computeroutput> (morphology only)</para>
+               <para>MAF: <computeroutput>-</computeroutput> (morphology only)</para>
+               <para>SynAF: <computeroutput>-</computeroutput> (tbc)</para>
+               <para>SemAF: <computeroutput>+</computeroutput> (tbc)</para>
+               <para>LAF: <computeroutput>+</computeroutput> (ISOcat)</para>
+            </section>
+         </section>
+         <section>
+            <title>D. Levels of linguistic analysis: sequential structure</title>
+            <para>For a particular level of linguistic analysis, the vocabulary should</para>
+            <itemizedlist>
+               <listitem>
+                  <para>define (<computeroutput>+</computeroutput>) or address (<computeroutput>(+)</computeroutput>) the relevant units of annotation, and</para>
+               </listitem>
+               <listitem>
+                  <para>permit to navigate among units of annotation (e.g., retrieving the next annotation of the same kind)</para>
+               </listitem>
+            </itemizedlist>
+            <para>As for "navigation" relations between adjacent units: For different levels of linguistic annotation (e.g., morphology, word-level annotations), the vocabulary should provide an explicit means to identify the next (or preceding) unit of annotation. For pre-RDF vocabularies, this can be encoded in the structure of a a file (e.g., in XML or CoNLL formats), for RDF vocabularies, this must be explicit triples.</para>
+            <para>In Web Annotation, this is absent, hence <computeroutput>-</computeroutput>.
+NIF defines such properties for limited number of possible relations among concepts, e.g. <computeroutput>nif:nextWord</computeroutput> or <computeroutput>nif:nextSentance</computeroutput>, but not for others (e.g., morphs).</para>
+            <section>
+               <title>D.1 Word-level annotation: sequence of words</title>
+               <para>NIF: <computeroutput>+</computeroutput> (<computeroutput>nif:nextWord</computeroutput>)</para>
+               <para>Web Annotation: <computeroutput>-</computeroutput> (no sequence properties whatsoever)</para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput> (<computeroutput>nif:nextWord</computeroutput>)</para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (words are not a designated datatype)</para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (tbc., implicitly via offsets?)</para>
+               <para>SynAF: <computeroutput>(+)</computeroutput> (tbc: implicitly via XML?)</para>
+               <para>MAF: <computeroutput>(+)</computeroutput> (tbc: implicitly via XML?)</para>
+               <para>SemAF: <computeroutput>(+)</computeroutput> (tbc: implcitly via XML?)</para>
+            </section>
+            <section>
+               <title>D.2 Sentence-level annotation: sequence of sentences</title>
+               <para>NIF: <computeroutput>+</computeroutput> (<computeroutput>nif:nextSentence</computeroutput>)</para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (tbc)</para>
+               <para>MAF: <computeroutput>(+)</computeroutput> (tbc)</para>
+               <para>SemAF: <computeroutput>(+)</computeroutput> (tbc)</para>
+               <para>SynAF: <computeroutput>(+)</computeroutput> (tbc)</para>
+            </section>
+            <section>
+               <title>D.3 Morphology: sequence of morphological segments</title>
+               <para>
+                  <computeroutput>cats</computeroutput> = <computeroutput>cat</computeroutput> + <computeroutput>s</computeroutput> with <computeroutput>cat "directly precedes" s</computeroutput>.</para>
+               <para>NIF: <computeroutput>-</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>For a possible solution, cf. <link xl:href="https://github.com/acoli-repo/ligt">Ligt</link>.</para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (tbc)</para>
+               <para>MAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>(-)</computeroutput> (tbc)</para>
+               <para>SemAF: <computeroutput>(-)</computeroutput> (tbc)</para>
+            </section>
+            <section>
+               <title>D.4 Syntax: discontinuous multi-word segments</title>
+               <para>represent discontinuous multi-word segments	represent syntactic phrases, regardless of their sequential order</para>
+               <para>Example:
+```
+[What] did they laugh [about]?
+```</para>
+               <para>At a deep level, the phrase here is <computeroutput>[about what]</computeroutput>. If this can be represented directly, mark <computeroutput>+</computeroutput>. If the system requires the introduction of a zero element, mark as <computeroutput>(-)</computeroutput>.</para>
+               <para>Note that this is different from the annotation of discontinuous strings, as the words being connected can have an internal syntactic structure.</para>
+               <para>Web Annotation: <computeroutput>(-)</computeroutput> (no vocabulary for phrase-level structures, could be added, e.g., from POWLA)</para>
+               <para>NIF: <computeroutput>-</computeroutput> (NIF phrases are strings, i.e., necessarily continuous)</para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (no phrases, could be added when combined with POWLA)</para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (no examples known)</para>
+               <para>MAF: tbc.</para>
+               <para>SynAF: <computeroutput>(+)</computeroutput> (tbc., syntax is likely the reason for having such nodes in LAF)</para>
+               <para>SemAF: <computeroutput>(+)</computeroutput> (tbc., in analogy with SynAF?)</para>
+            </section>
+            <section>
+               <title>D.5 Syntax/text structure: sequence of elements within a phrase</title>
+               <para>Within the vocabulary, we should be able to quickly navigate from one sibling to the next.</para>
+               <para>Lacking in NIF and Web Annotation, hence <computeroutput>-</computeroutput>, but provided by <link xl:href="http://purl.org/powla">POWLA</link>, an RDF/OWL reconstruction of LAF.</para>
+               <para>NIF: <computeroutput>(-)</computeroutput> (depends on internal structure of the phrase, if these are words, this could be <computeroutput>nif:nextWord</computeroutput>, if these are phrases, this is undefined)</para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>+</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>+</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput> (no phrases)</para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (tbc)</para>
+               <para>SynAF: <computeroutput>+</computeroutput> (tbc)</para>
+               <para>MAF: <computeroutput>-</computeroutput> (tbc)</para>
+               <para>SemAF: <computeroutput>+</computeroutput> (tbc., e.g., for discourse annotation)</para>
+            </section>
+         </section>
+         <section>
+            <title>E. Levels of linguistic analysis: relational structure</title>
+            <para>(At least) two kinds of relations must be distinguished: Relations there one node contains the other (hierarchical structure, e.g., phrase structure syntax) and relations between independent nodes (relational structure, e.g., dependency syntax, coreference, etc.).</para>
+            <para>Web Annotation does not provide any vocabulary for relations between annotations (or bodies). Offset-based selectors do, however, permit reasoning over offsets that can be (ab)used to indicate hierarchical structures. However, this does not hold between annotations, but between bodies only, hence <computeroutput>(-)</computeroutput>, because hierarchical structures between co-extensional elements cannot be expressed.</para>
+            <para>Similarly, NIF encodes hierarchical structure by means of <computeroutput>nif:subString</computeroutput>, but note that this is 'not' a relation between LAF nodes (~ <computeroutput>nif:AnnotationUnit</computeroutput>) but between LAF regions (<computeroutput>nif:String</computeroutput>). Hence, this is <computeroutput>(-)</computeroutput>.</para>
+            <para>Example for hierarchical relations between co-extensional elements:</para>
+            <para>```
+[S [VF [NP [NE Peter ] ] ] [LK [V war ] ] [MF [ADVX [ADV nicht] [ADV zuhause] ] ] ]
+```</para>
+            <para>German, 'Peter wasn't home', example inspired by <link xl:href="http://www.sfs.uni-tuebingen.de/en/ascl/resources/corpora/tueba-dz.html">TüBa-D/Z corpus</link>
+            </para>
+            <para>```
+VF -&gt; Peter (Vorfeld, syntactic position)
+NP -&gt; Peter (Noun Phrase, constituent at VF position)
+NE -&gt; Peter (Named Entity that constitutes the NP)
+```</para>
+            <para>These are co-extensional, but their hierarchical organization (in the annotation) is meaningful and must not be reversed. In the following, NIF and WA all have <computeroutput>(-)</computeroutput> for hierarchical relations.</para>
+            <section>
+               <title>E.1 Morphology: relations</title>
+               <para>hierachical/other relations to be confirmed, cf. OntoLex-Morph and MAF</para>
+               <para>Vocabulary should either provide the vocabulary or refer to an external terminology repository that provides the necessary vocabulary</para>
+               <para>Ligt: <computeroutput>(-)</computeroutput> (no examples, via link with OntoLex-Morph?)</para>
+               <para>POWLA: <computeroutput>(-)</computeroutput> (via link with OntoLex-Morph?)</para>
+               <para>NIF: <computeroutput>-</computeroutput> (no morphologial segmentation)</para>
+               <para>Web Annotation: <computeroutput>(-)</computeroutput> (via link with external vocabulary, e.g., OntoLex-Morph?)</para>
+               <para>LAF: tbc</para>
+               <para>MAF: <computeroutput>+</computeroutput> (tbc)</para>
+               <para>SynAF: <computeroutput>-</computeroutput> (tbc)</para>
+               <para>SemAF: <computeroutput>-</computeroutput> (tbc)</para>
+            </section>
+            <section>
+               <title>E.2 Dependency syntax</title>
+               <para>no hierarchical relations, to be confirmed whether primary and secondary dependencies are to be distinguished (cf. https://universaldependencies.org/), cf. SynAF (other standards?)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>-</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>+</computeroutput> (native vocabulary)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (via external vocabulary, e.g., OLiA)</para>
+               <para>NIF: <computeroutput>(+)</computeroutput> (not part of NIF core, but example implementation with OLiA for Stanford Parser)</para>
+               <para>SynAF: <computeroutput>+</computeroutput> (tbc)</para>
+               <para>SemAF: <computeroutput>(-)</computeroutput> (tbc)</para>
+               <para>MAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (voa external vocabulary: ISOcat)</para>
+            </section>
+            <section>
+               <title>E.3 Phrase structure syntax: hierarchical relations</title>
+               <para>hierarchical relations, must be annotatable, see SynAF, to be confirmed whether primary and secondary edges are to be distinguished (cf. <link xl:href="https://www.ims.uni-stuttgart.de/forschung/ressourcen/werkzeuge/TIGERSearch/doc/html/TigerXML.html">TIGER XML</link>)</para>
+               <para>NIF: <computeroutput>(-)</computeroutput> (labelled edges do not seem be foreseen, must be encoded as phrase-level features)</para>
+               <para>SynAF: <computeroutput>+</computeroutput> (tbc)</para>
+               <para>LAF: <computeroutput>+</computeroutput> (via external vocabulary, ISOcat)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (labels via external vocabulary, OLiA)</para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (via POWLA and OLiA)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>SemAF: tbc</para>
+            </section>
+            <section>
+               <title>E.4 Phrase structure syntax: other relations</title>
+               <para>to be confirmed, e.g., for movement/traces, see SynAF. 
+Note that an indirect encoding by means of empty elements may be possible under certain circumstances, cf. the modelling of syntactic movement by means of traces in generative syntax.</para>
+               <para>CoNLL-RDF: <computeroutput>(-)</computeroutput> (support for Penn-style encoding of traces and coindexing, these need to be manually resolved, though)</para>
+               <para>SynAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (via external vocabulary, e.g., OLiA)</para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (via external vocabulary, ISOCat)</para>
+               <para>MAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>SemAF: tbc</para>
+               <para>NIF: <computeroutput>(-)</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>-</computeroutput> (no relational annotation foreseen)</para>
+            </section>
+            <section>
+               <title>E.5 Semantics: relations</title>
+               <para>cf. SemAF, must cover a broad inventory of relations, including TimeML, PropBank/FrameNet-style semantic roles, different forms of discourse annotation (RST: hierarchical, PDTB: non-hierarchical), coreference, etc.</para>
+               <para>In order to prevent unlimited growth of the vocabulary, semantic annotations should use refer to a(n extensible) terminology repository rather than aiming to provide an exhaustive list 'within the vocabulary'.</para>
+               <para>SemAF: <computeroutput>+</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (via OLiA)</para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (native support for semantic roles)</para>
+               <para>NIF: <computeroutput>(-)</computeroutput> (can be extended, e.g., a FrameNet extension, using a separate namespace)</para>
+               <para>Web Annotation: <computeroutput>-</computeroutput> (no relational annotation foreseen)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (via ISOcat)</para>
+               <para>SynAF: <computeroutput>(-)</computeroutput> (tbc.)</para>
+            </section>
+            <section>
+               <title>Other (to be added)</title>
+               <para/>
+            </section>
+         </section>
+         <section>
+            <title>F. Data structures for novel applications</title>
+            <para>Aside from the types of annotation listed below, RDF-based technology enables better support for phenomena that no community standard currently does exist for. These are usecases that involve linking across documents. Note that requirements for "conventional annotations" (such as covered by existing W3C, ISO or other standards) are listed below.</para>
+            <section>
+               <title>F.1 Intertextual relations</title>
+               <para>Link text passages from different documents that correspond to each other, e.g., because of text reuse. There should be an encoding for undirected overlap (if two sources derive from the same, anonymous source or the direction of reuse is uncear) and a different encoding for confirmed text reuse.</para>
+               <para>Motivation: Digital Humanities</para>
+               <para>Currently no native vocabulary within Web Annotation or NIF, but both can be extended with user-provided properties for the purpose, hence <computeroutput>(-)</computeroutput>.</para>
+               <para>NIF: <computeroutput>(-)</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>(-)</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (a partial linking functionality can be implemented using CoNLL-Merge, then corresponding tokens in different editions refer to the same <computeroutput>nif:Word</computeroutput> -- which may be an empty token, see alignment below)</para>
+               <para>LAF: <computeroutput>(-)</computeroutput> (tbc.)</para>
+               <para>MAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>SemAF: <computeroutput>-</computeroutput> (tbc)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+            </section>
+            <section>
+               <title>F.2 Collation and alignment</title>
+               <para>Alignment: Parallel corpora are conventionally used, but current technology is restricted to bilingual pairs (e.g., <link xl:href="https://www.cl.uzh.ch/en/texttechnologies/research/corpus-linguistics/paralleltreebanks/treealigner.ht">TreeAligner</link>. For developing language-independent applications and tools, it would be beneficial to support alignment between more than two languages. Different kinds of alignments need to be distinguished: Undirected alignment (the intuitive default) and directed alignment (as produced by standard alignment tools that produce either m:1 or 1:n alignments).</para>
+               <para>Collation: For different editions of the same document (e.g., different manuscripts), align corresponding passages in an order-insensitive way. Note that collation typically extends to <emphasis>much</emphasis> more than two sources. For existing tools, cf. <link xl:href="https://collatex.net/doc/">CollateX</link>, but note that it does not support annotated data. Collation as such is undirected, but it should be possible to assert the direction of text reuse.</para>
+               <para>Motivation: NLP (parallel corpora) and Digital Humanities (collation)</para>
+               <para>Currently no native vocabulary within Web Annotation or NIF, but both can be extended with user-provided properties or classes for the purpose, hence <computeroutput>(-)</computeroutput>.</para>
+               <para>Web Annotation: <computeroutput>(-)</computeroutput> (extensible for undirected alignment for more than 2 languages: "alignment" as subclass of <computeroutput>oa:Annotation</computeroutput> with multiple targets)</para>
+               <para>NIF: <computeroutput>(-)</computeroutput>
+               </para>
+               <para>For original TSV ("CoNLL") annotations, such data can be created with <link xl:href="https://github.com/acoli-repo/conll">CoNLL-Merge</link> and represented in RDF using the <link xl:href="https://github.com/acoli-repo/conll-rdf">CoNLL-RDF vocabulary</link>.</para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput> (directed alignment only, encoded in CoNLL columns, i.e., CoNLL-RDF properties, cf. <link xl:href="https://github.com/acoli-repo/rdf4discourse/blob/master/discourse-markers/parcor/opus/Europarl.de-it.annotated-sample.conll">here</link>)</para>
+               <para>LAF: <computeroutput>-</computeroutput> (tbc., no examples known)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>MAF: <computeroutput>-</computeroutput>
+               </para>
+               <para>SynAF: <computeroutput>-</computeroutput> (tbc)</para>
+               <para>SemAF: <computeroutput>-</computeroutput> (tbc)</para>
+               <para>POWLA: <computeroutput>(-)</computeroutput> (can be extended)</para>
+            </section>
+            <section>
+               <title>F.3 Links with lexical resources</title>
+               <para>Link an expression with a glossary or a dictionary, e.g., to provide attestation information (within a dictionary) or to provide lexical information (within a corpus). Approach should be coordinated with <link xl:href="https://github.com/acoli-repo/ontolex-frac">OntoLex-FrAC</link>.</para>
+               <para>Motivation: Digital Philologies</para>
+               <para>Currently no native vocabulary within Web Annotation or NIF, but according to FrAC draft, either can be used in conjunction with OntoLex-FrAC, hence <computeroutput>(+)</computeroutput>. In fact, this can be extended to <emphasis>any</emphasis> other RDF vocabulary applied to a linguistic corpus.</para>
+               <para>NIF: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>Ligt: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>POWLA: <computeroutput>(+)</computeroutput>
+               </para>
+               <para>SemAF: tbc</para>
+               <para>SynAF: tbc</para>
+               <para>MAF: tbc</para>
+               <para>LAF: tbc (imagineable, but no example known)</para>
+            </section>
+            <section>
+               <title>F.4 Dialog annotation</title>
+               <para>Represent contributions of different dialog partners as indepndent texts/documents/media files and annotate them separately, but within the same annotation graph (tbc: could be required by SemAF).</para>
+               <para>This is necessary, for example, if multiple recorders are being used, and annotation may switch from the (best) recorder for participant A to the (best) recorder for participant B.</para>
+               <para>Not addressed in NIF: <computeroutput>-</computeroutput>
+Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence <computeroutput>(+)</computeroutput>
+               </para>
+               <para>Web Annotation: <computeroutput>-</computeroutput> (tbc., no example known)</para>
+               <para>SemAF: <computeroutput>+</computeroutput> (tbc)</para>
+               <para>POWLA: <computeroutput>(+)</computeroutput> (extensible)</para>
+               <para>LAF: <computeroutput>(+)</computeroutput> (tbc., via ISOcat?)</para>
+               <para>SynAF: tbc</para>
+               <para>MAF: <computeroutput>-</computeroutput> (tbc)</para>
+               <para>Ligt: <computeroutput>-</computeroutput>
+               </para>
+               <para>CoNLL-RDF: <computeroutput>-</computeroutput> (only if annotated as plain text, no formal vocabulary)</para>
+            </section>
+            <section>
+               <title>Other (please add)</title>
+               <para>
+...</para>
+            </section>
+         </section>
+         <section>
+            <title>G. Best practices beyond vocabulary</title>
+            <para>Sections A-F are primarily about standardization. To provide best practices are yet another requirement, but are less part of standardization / vocabulary development rather than the application of existing conventions. Whether these are within scope of the current discussion is yet to be discussed.</para>
+            <section>
+               <title>G.1 Recommended best practices for IRI identifiers used for linguistic annotations</title>
+               <para>It would be helpful to have a set of recommended best practices for IRI identifiers used for linguistic annotations. E.g. when/if to use ARKs vs Handles vs DOIs, vs PURLs (also see https://project-thor.readme.io/docs/project-glossary and https://github.com/ld4lt/linguistic-annotation/issues/2).</para>
+               <para>Apparently, all vocabularies discussed here remain agnostic about IRIs (except for fragment identifiers).</para>
+            </section>
+         </section>
+      </section>
+   </required-features-as-docbook>
+   <standards-regex>NIF|NIF 2\.0|NIF 2\.1|CoNLL-RDF|Ligt|Web Annotation|Open Annotation|ISO and derivatives|POWLA|PAULA|LAF|MAF|SynAF|SemAF</standards-regex>
+   <parse-pass-1>
+      <survey>
+         <item>
+            <aspect>A.1 RDF serialization</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+            <comment>RDF</comment>
+         </item>
+         <item>
+            <aspect>A.1 RDF serialization</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.1 RDF serialization</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.1 RDF serialization</aspect>
+            <standard>LAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.1 RDF serialization</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.1 RDF serialization</aspect>
+            <standard>SynAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.1 RDF serialization</aspect>
+            <standard>SemAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.2 Extent of standardization</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+            <comment>widely used community standard, and referred to in W3C standards</comment>
+         </item>
+         <item>
+            <aspect>A.2 Extent of standardization</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>this basically implements LAF</comment>
+         </item>
+         <item>
+            <aspect>A.2 Extent of standardization</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.2 Extent of standardization</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.2 Extent of standardization</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.2 Extent of standardization</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.2 Extent of standardization</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.3 Documentation</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+            <comment>for NIF 2.0</comment>
+         </item>
+         <item>
+            <aspect>A.3 Documentation</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>via https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf</comment>
+         </item>
+         <item>
+            <aspect>A.3 Documentation</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+            <comment>link tbc.</comment>
+         </item>
+         <item>
+            <aspect>A.3 Documentation</aspect>
+            <standard>SynAF</standard>
+            <support>-</support>
+            <comment>unless link/information provided</comment>
+         </item>
+         <item>
+            <aspect>A.3 Documentation</aspect>
+            <standard>SemAF</standard>
+            <support>-</support>
+            <comment>unless link/information provided</comment>
+         </item>
+         <item>
+            <aspect>A.3 Documentation</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>on-line documentation dated, more up-to-date documentation in Cimiano et al. 2020, but this is not open access</comment>
+         </item>
+         <item>
+            <aspect>A.3 Documentation</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>partially documented only</comment>
+         </item>
+         <item>
+            <aspect>A.4 IRI fragment identifiers for strings</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.4 IRI fragment identifiers for strings</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.4 IRI fragment identifiers for strings</aspect>
+            <standard>POWLA</standard>
+            <support>(-)</support>
+            <comment>not specified, to be provided by complementary vocabulary, e.g., NIF or WA</comment>
+         </item>
+         <item>
+            <aspect>A.4 IRI fragment identifiers for strings</aspect>
+            <standard>LAF</standard>
+            <support>-</support>
+            <comment>proprietary means of defining selectors</comment>
+         </item>
+         <item>
+            <aspect>A.5 Explicit selectors</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.5 Explicit selectors</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>recent publications recommend to rely on external vocabularies instead</comment>
+         </item>
+         <item>
+            <aspect>A.5 Explicit selectors</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.6 Explicit context strings</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.6 Explicit context strings</aspect>
+            <standard>POWLA</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.6 Explicit context strings</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>A.7 API specifications for web services</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+            <comment>https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</comment>
+         </item>
+         <item>
+            <aspect>A.8 Assign data categories</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+            <comment>nif:oliaLink, pointing to OLiA</comment>
+         </item>
+         <item>
+            <aspect>A.8 Assign data categories</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>LAF and other ISO/TC37 standards: pointing to ISOCat, no longer maintained, successor solutions are only emerging: CCR, DatCatInfo</comment>
+         </item>
+         <item>
+            <aspect>A.8 Assign data categories</aspect>
+            <standard>MAF</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>A.8 Assign data categories</aspect>
+            <standard>SemAF</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>A.8 Assign data categories</aspect>
+            <standard>SynAF</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>A.8 Assign data categories</aspect>
+            <standard>Ligt</standard>
+            <support>(+)</support>
+            <comment>Not specified, but designed as a NIF fragment, so, nif:oliaLink could be used</comment>
+         </item>
+         <item>
+            <aspect>A.9 Compatible with Web Annotation vocabulary</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+            <comment>Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</comment>
+         </item>
+         <item>
+            <aspect>A.9 Compatible with Web Annotation vocabulary</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>A.9 Compatible with Web Annotation vocabulary</aspect>
+            <standard>Ligt</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>A.9 Compatible with Web Annotation vocabulary</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>A partial reconstruction of LAF within WA has been described by Verspoor et al. 2012, but this does not seem to have been adopted in subsequent research nor evaluated by any third party.</comment>
+         </item>
+         <item>
+            <aspect>A.9 Compatible with Web Annotation vocabulary</aspect>
+            <standard>MAF</standard>
+            <support>(+)</support>
+            <comment>not checked in detail, but cf. LAF</comment>
+         </item>
+         <item>
+            <aspect>A.9 Compatible with Web Annotation vocabulary</aspect>
+            <standard>SemAF</standard>
+            <support>(+)</support>
+            <comment>not checked in detail, but cf. LAF</comment>
+         </item>
+         <item>
+            <aspect>A.9 Compatible with Web Annotation vocabulary</aspect>
+            <standard>SynAF</standard>
+            <support>(+)</support>
+            <comment>not checked in detail, but cf. LAF</comment>
+         </item>
+         <item>
+            <aspect>A.10 Compatible with NIF 2.0 core vocabulary</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.10 Compatible with NIF 2.0 core vocabulary</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+            <comment>extends NIF vocabulary with specifications for morphology (interlinear glossed text); still under development, see here</comment>
+         </item>
+         <item>
+            <aspect>A.10 Compatible with NIF 2.0 core vocabulary</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>A.10 Compatible with NIF 2.0 core vocabulary</aspect>
+            <standard>LAF</standard>
+            <support>-</support>
+            <comment>NIF systematically conflates LAF data structures, see A.11</comment>
+         </item>
+         <item>
+            <aspect>A.11 Compatible with ISO standards</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+            <comment>no generic data structures for linguistic annotation; conflates regions and nodes, see below</comment>
+         </item>
+         <item>
+            <aspect>A.11 Compatible with ISO standards</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+            <comment>only a specific subset, possibly MAF</comment>
+         </item>
+         <item>
+            <aspect>A.11 Compatible with ISO standards</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.11 Compatible with ISO standards</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.11 Compatible with ISO standards</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>A.11 Compatible with ISO standards</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B. Expressiveness</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.1 Pointers to primary data</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.1 Pointers to primary data</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>pointers to data structures, not primary data</comment>
+         </item>
+         <item>
+            <aspect>B.1 Pointers to primary data</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>offset-based pointers possible, last publications recommend to use external vocabularies</comment>
+         </item>
+         <item>
+            <aspect>B.1 Pointers to primary data</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+            <comment>XPointers</comment>
+         </item>
+         <item>
+            <aspect>B.1 Pointers to primary data</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+            <comment>from LAF</comment>
+         </item>
+         <item>
+            <aspect>B.1 Pointers to primary data</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+            <comment>from LAF</comment>
+         </item>
+         <item>
+            <aspect>B.1 Pointers to primary data</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+            <comment>from LAF</comment>
+         </item>
+         <item>
+            <aspect>B.2 Pointers: Vocabulary for explicit references</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.2 Pointers: Vocabulary for explicit references</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>offset-based pointers possible, last publications recommend to use external vocabularies</comment>
+         </item>
+         <item>
+            <aspect>B.2 Pointers: Vocabulary for explicit references</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.2 Pointers: Vocabulary for explicit references</aspect>
+            <standard>LAF</standard>
+            <support>-</support>
+            <comment>no RDF statements</comment>
+         </item>
+         <item>
+            <aspect>B.3 Pointers: User-provided selectors</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+            <comment>would be considered out of scope</comment>
+         </item>
+         <item>
+            <aspect>B.3 Pointers: User-provided selectors</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>in combination with Web Annotation</comment>
+         </item>
+         <item>
+            <aspect>B.3 Pointers: User-provided selectors</aspect>
+            <standard>LAF</standard>
+            <support>(-)</support>
+            <comment>actually, this is hard to tell, technically, this would be possible, but there don't seem to be documented examples</comment>
+         </item>
+         <item>
+            <aspect>B.4 Pointers: Support the annotation of continuous strings</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.4 Pointers: Support the annotation of continuous strings</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.4 Pointers: Support the annotation of continuous strings</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.4 Pointers: Support the annotation of continuous strings</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.4 Pointers: Support the annotation of continuous strings</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.4 Pointers: Support the annotation of continuous strings</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.4 Pointers: Support the annotation of continuous strings</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.5 Pointers: Annotation of discontinuous strings</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+            <comment>annotations such as ext:offset_0_14_23_32 are not considered nor supported</comment>
+         </item>
+         <item>
+            <aspect>B.5 Pointers: Annotation of discontinuous strings</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>a terminal is offset-defined, so it apparently has to be a continuous string, but nonterminals can aggregate discontinuous sequences of terminals</comment>
+         </item>
+         <item>
+            <aspect>B.5 Pointers: Annotation of discontinuous strings</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>in principle, discontinuous aggregates could exist, but there are no examples for that nor any model in current IGT annotation</comment>
+         </item>
+         <item>
+            <aspect>B.5 Pointers: Annotation of discontinuous strings</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>the existence of discontinuous anchors needs to be confirmed, but nodes can aggregate other nodes regardless of their position</comment>
+         </item>
+         <item>
+            <aspect>B.5 Pointers: Annotation of discontinuous strings</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.5 Pointers: Annotation of discontinuous strings</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.5 Pointers: Annotation of discontinuous strings</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.6 Pointers: Annotation of media files</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.6 Pointers: Annotation of media files</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.6 Pointers: Annotation of media files</aspect>
+            <standard>LAF</standard>
+            <support>(-)</support>
+            <comment>tbc.</comment>
+         </item>
+         <item>
+            <aspect>B.7 Pointers: Support the annotation of timestamps/timelines</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.7 Pointers: Support the annotation of timestamps/timelines</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>if combined with Web Annotation</comment>
+         </item>
+         <item>
+            <aspect>B.7 Pointers: Support the annotation of timestamps/timelines</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.7 Pointers: Support the annotation of timestamps/timelines</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>tbc.; CC: I'm pretty sure this has been addressed</comment>
+         </item>
+         <item>
+            <aspect>B.7 Pointers: Support the annotation of timestamps/timelines</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.7 Pointers: Support the annotation of timestamps/timelines</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.7 Pointers: Support the annotation of timestamps/timelines</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.8 Pointers: standoff annotation</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.8 Pointers: standoff annotation</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.8 Pointers: standoff annotation</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.8 Pointers: standoff annotation</aspect>
+            <standard>Ligt</standard>
+            <support>(+)</support>
+            <comment>no examples known</comment>
+         </item>
+         <item>
+            <aspect>B.8 Pointers: standoff annotation</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.8 Pointers: standoff annotation</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.8 Pointers: standoff annotation</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.9 Generic data structures for linguistic annotation: node != pointer</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.9 Generic data structures for linguistic annotation: node != pointer</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.9 Generic data structures for linguistic annotation: node != pointer</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>unclear</comment>
+         </item>
+         <item>
+            <aspect>B.9 Generic data structures for linguistic annotation: node != pointer</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.9 Generic data structures for linguistic annotation: node != pointer</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.9 Generic data structures for linguistic annotation: node != pointer</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.9 Generic data structures for linguistic annotation: node != pointer</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.10 Generic data structures for linguistic annotation: zero nodes</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+            <comment>the default encoding for annotations in NIF is by subclasses of nif:String</comment>
+         </item>
+         <item>
+            <aspect>B.10 Generic data structures for linguistic annotation: zero nodes</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+            <comment>from LAF</comment>
+         </item>
+         <item>
+            <aspect>B.10 Generic data structures for linguistic annotation: zero nodes</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.10 Generic data structures for linguistic annotation: zero nodes</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.10 Generic data structures for linguistic annotation: zero nodes</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.10 Generic data structures for linguistic annotation: zero nodes</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.10 Generic data structures for linguistic annotation: zero nodes</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.11 Generic data structures for linguistic annotation: edge ('relation')</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.11 Generic data structures for linguistic annotation: edge ('relation')</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.11 Generic data structures for linguistic annotation: edge ('relation')</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.11 Generic data structures for linguistic annotation: edge ('relation')</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.11 Generic data structures for linguistic annotation: edge ('relation')</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.11 Generic data structures for linguistic annotation: edge ('relation')</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+            <comment>tbc: restricted to certain relation types</comment>
+         </item>
+         <item>
+            <aspect>B.11 Generic data structures for linguistic annotation: edge ('relation')</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+            <comment>part of the old TIGER format, SynAF is marketed as TIGER2, so, it should keep that</comment>
+         </item>
+         <item>
+            <aspect>B.11.a Non-reified representation of edges</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+            <comment>nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</comment>
+         </item>
+         <item>
+            <aspect>B.11.a Non-reified representation of edges</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>for hierarchical relations only</comment>
+         </item>
+         <item>
+            <aspect>B.11.a Non-reified representation of edges</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.11.a Non-reified representation of edges</aspect>
+            <standard>LAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.11.a Non-reified representation of edges</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.11.a Non-reified representation of edges</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.11.a Non-reified representation of edges</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.12 Reified representation of edges (annotation relations)</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.12 Reified representation of edges (annotation relations)</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.12 Reified representation of edges (annotation relations)</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.12 Reified representation of edges (annotation relations)</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>reification" is not directly applicable to non-RDF data</comment>
+         </item>
+         <item>
+            <aspect>B.13 Generic data structures for linguistic annotation: graphs</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>B.13 Generic data structures for linguistic annotation: graphs</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.13 Generic data structures for linguistic annotation: graphs</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.13 Generic data structures for linguistic annotation: graphs</aspect>
+            <standard>Ligt</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>B.13 Generic data structures for linguistic annotation: graphs</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.13 Generic data structures for linguistic annotation: graphs</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.13 Generic data structures for linguistic annotation: graphs</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.14 Generic data structures for linguistic annotation: annotations</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+            <comment>nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</comment>
+         </item>
+         <item>
+            <aspect>B.14 Generic data structures for linguistic annotation: annotations</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.14 Generic data structures for linguistic annotation: annotations</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>B.14 Generic data structures for linguistic annotation: annotations</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>B.14 Generic data structures for linguistic annotation: annotations</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.14 Generic data structures for linguistic annotation: annotations</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.14 Generic data structures for linguistic annotation: annotations</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+            <comment>via OLiA</comment>
+         </item>
+         <item>
+            <aspect>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>via OLiA</comment>
+         </item>
+         <item>
+            <aspect>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>no example known</comment>
+         </item>
+         <item>
+            <aspect>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.16 Provenance and confidence</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+            <comment>NIF 2.0</comment>
+         </item>
+         <item>
+            <aspect>B.16 Provenance and confidence</aspect>
+            <standard>LAF</standard>
+            <support>-</support>
+            <comment>no RDF extension possible</comment>
+         </item>
+         <item>
+            <aspect>B.16 Provenance and confidence</aspect>
+            <standard>POWLA</standard>
+            <support>(-)</support>
+         </item>
+         <item>
+            <aspect>B.16 Provenance and confidence</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+         </item>
+         <item>
+            <aspect>B.17 Concurrent annotation</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>B.17 Concurrent annotation</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.17 Concurrent annotation</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.17 Concurrent annotation</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>no example known</comment>
+         </item>
+         <item>
+            <aspect>B.17 Concurrent annotation</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.17 Concurrent annotation</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.17 Concurrent annotation</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.18 Sequence of annotation units</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+            <comment>only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</comment>
+         </item>
+         <item>
+            <aspect>B.18 Sequence of annotation units</aspect>
+            <standard>Ligt</standard>
+            <support>(+)</support>
+            <comment>for native annotation units</comment>
+         </item>
+         <item>
+            <aspect>B.18 Sequence of annotation units</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.18 Sequence of annotation units</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.18 Sequence of annotation units</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.18 Sequence of annotation units</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.18 Sequence of annotation units</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.19 annotation values: plain literals</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.19 annotation values: plain literals</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.19 annotation values: plain literals</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.19 annotation values: plain literals</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.19 annotation values: plain literals</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.19 annotation values: plain literals</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.19 annotation values: plain literals</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>B.20 annotation values: feature structures</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.20 annotation values: feature structures</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+            <comment>e.g., using OLiA</comment>
+         </item>
+         <item>
+            <aspect>B.20 annotation values: feature structures</aspect>
+            <standard>Ligt</standard>
+            <support>(+)</support>
+            <comment>no example known</comment>
+         </item>
+         <item>
+            <aspect>B.20 annotation values: feature structures</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>B.20 annotation values: feature structures</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>B.20 annotation values: feature structures</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>B.20 annotation values: feature structures</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.1 Word-level annotations: word unit</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+            <comment>nif:Word</comment>
+         </item>
+         <item>
+            <aspect>C.1 Word-level annotations: word unit</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>powla:Terminal, but can be sub-token</comment>
+         </item>
+         <item>
+            <aspect>C.1 Word-level annotations: word unit</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.1 Word-level annotations: word unit</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.1 Word-level annotations: word unit</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.1 Word-level annotations: word unit</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.1 Word-level annotations: word unit</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.2 Sentence-level annotation: sentence unit</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+            <comment>nif:Sentence</comment>
+         </item>
+         <item>
+            <aspect>C.2 Sentence-level annotation: sentence unit</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.2 Sentence-level annotation: sentence unit</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>powla:Root, but this doesn't have to be sentential</comment>
+         </item>
+         <item>
+            <aspect>C.2 Sentence-level annotation: sentence unit</aspect>
+            <standard>LAF</standard>
+            <support>(-)</support>
+            <comment>tbc.</comment>
+         </item>
+         <item>
+            <aspect>C.2 Sentence-level annotation: sentence unit</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>C.2 Sentence-level annotation: sentence unit</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.2 Sentence-level annotation: sentence unit</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+            <comment>tbc.</comment>
+         </item>
+         <item>
+            <aspect>C.3 morphology: morphological segments</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+            <comment>no designated vocabulary, can be accessed as substrings, but not in all cases.</comment>
+         </item>
+         <item>
+            <aspect>C.3 morphology: morphological segments</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>C.3 morphology: morphological segments</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>no designated vocabulary, but can be modelled as segments</comment>
+         </item>
+         <item>
+            <aspect>C.3 morphology: morphological segments</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+            <comment>tbc.</comment>
+         </item>
+         <item>
+            <aspect>C.3 morphology: morphological segments</aspect>
+            <standard>SynAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>C.3 morphology: morphological segments</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>C.3 morphology: morphological segments</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>no designated vocabulary, but can be added</comment>
+         </item>
+         <item>
+            <aspect>C.4 syntax/text structure: node labels/types</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+            <comment>predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</comment>
+         </item>
+         <item>
+            <aspect>C.4 syntax/text structure: node labels/types</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>C.4 syntax/text structure: node labels/types</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+            <comment>using an external vocabulary, OLiA</comment>
+         </item>
+         <item>
+            <aspect>C.4 syntax/text structure: node labels/types</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+            <comment>no examples for phrase-level annotations</comment>
+         </item>
+         <item>
+            <aspect>C.4 syntax/text structure: node labels/types</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+            <comment>ISOcat</comment>
+         </item>
+         <item>
+            <aspect>C.4 syntax/text structure: node labels/types</aspect>
+            <standard>SynAF</standard>
+            <support>(+)</support>
+            <comment>ISOcat, for syntax, but hard-wired data structures only</comment>
+         </item>
+         <item>
+            <aspect>C.4 syntax/text structure: node labels/types</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+            <comment>no syntax nodes</comment>
+         </item>
+         <item>
+            <aspect>C.4 syntax/text structure: node labels/types</aspect>
+            <standard>SemAF</standard>
+            <support>(+)</support>
+            <comment>ISOcat, for text/discourse, but hard-wired data structures only</comment>
+         </item>
+         <item>
+            <aspect>C.5 semantics: node labels/types</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+            <comment>NIF supports entity linking, but no other form of semantic annotation, hence (-)</comment>
+         </item>
+         <item>
+            <aspect>C.5 semantics: node labels/types</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+            <comment>using an external vocabulary, OLiA</comment>
+         </item>
+         <item>
+            <aspect>C.5 semantics: node labels/types</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+            <comment>morphology only</comment>
+         </item>
+         <item>
+            <aspect>C.5 semantics: node labels/types</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+            <comment>morphology only</comment>
+         </item>
+         <item>
+            <aspect>C.5 semantics: node labels/types</aspect>
+            <standard>SynAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>C.5 semantics: node labels/types</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>C.5 semantics: node labels/types</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+            <comment>ISOcat</comment>
+         </item>
+         <item>
+            <aspect>D.1 Word-level annotation: sequence of words</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+            <comment>nif:nextWord</comment>
+         </item>
+         <item>
+            <aspect>D.1 Word-level annotation: sequence of words</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>D.1 Word-level annotation: sequence of words</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>words are not a designated datatype</comment>
+         </item>
+         <item>
+            <aspect>D.1 Word-level annotation: sequence of words</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>tbc., implicitly via offsets?</comment>
+         </item>
+         <item>
+            <aspect>D.1 Word-level annotation: sequence of words</aspect>
+            <standard>SynAF</standard>
+            <support>(+)</support>
+            <comment>tbc: implicitly via XML?</comment>
+         </item>
+         <item>
+            <aspect>D.1 Word-level annotation: sequence of words</aspect>
+            <standard>MAF</standard>
+            <support>(+)</support>
+            <comment>tbc: implicitly via XML?</comment>
+         </item>
+         <item>
+            <aspect>D.1 Word-level annotation: sequence of words</aspect>
+            <standard>SemAF</standard>
+            <support>(+)</support>
+            <comment>tbc: implcitly via XML?</comment>
+         </item>
+         <item>
+            <aspect>D.2 Sentence-level annotation: sequence of sentences</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>+</support>
+            <comment>nif:nextSentence</comment>
+         </item>
+         <item>
+            <aspect>D.2 Sentence-level annotation: sequence of sentences</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>D.2 Sentence-level annotation: sequence of sentences</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.2 Sentence-level annotation: sequence of sentences</aspect>
+            <standard>MAF</standard>
+            <support>(+)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.2 Sentence-level annotation: sequence of sentences</aspect>
+            <standard>SemAF</standard>
+            <support>(+)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.2 Sentence-level annotation: sequence of sentences</aspect>
+            <standard>SynAF</standard>
+            <support>(+)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.3 Morphology: sequence of morphological segments</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>D.3 Morphology: sequence of morphological segments</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>D.3 Morphology: sequence of morphological segments</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.3 Morphology: sequence of morphological segments</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>D.3 Morphology: sequence of morphological segments</aspect>
+            <standard>SynAF</standard>
+            <support>(-)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.3 Morphology: sequence of morphological segments</aspect>
+            <standard>SemAF</standard>
+            <support>(-)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.4 Syntax: discontinuous multi-word segments</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+            <comment>NIF phrases are strings, i.e., necessarily continuous</comment>
+         </item>
+         <item>
+            <aspect>D.4 Syntax: discontinuous multi-word segments</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>D.4 Syntax: discontinuous multi-word segments</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>D.4 Syntax: discontinuous multi-word segments</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>no examples known</comment>
+         </item>
+         <item>
+            <aspect>D.4 Syntax: discontinuous multi-word segments</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>D.4 Syntax: discontinuous multi-word segments</aspect>
+            <standard>SynAF</standard>
+            <support>(+)</support>
+            <comment>tbc., syntax is likely the reason for having such nodes in LAF</comment>
+         </item>
+         <item>
+            <aspect>D.4 Syntax: discontinuous multi-word segments</aspect>
+            <standard>SemAF</standard>
+            <support>(+)</support>
+            <comment>tbc., in analogy with SynAF?</comment>
+         </item>
+         <item>
+            <aspect>D.5 Syntax/text structure: sequence of elements within a phrase</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+            <comment>depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</comment>
+         </item>
+         <item>
+            <aspect>D.5 Syntax/text structure: sequence of elements within a phrase</aspect>
+            <standard>POWLA</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>D.5 Syntax/text structure: sequence of elements within a phrase</aspect>
+            <standard>Ligt</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>D.5 Syntax/text structure: sequence of elements within a phrase</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.5 Syntax/text structure: sequence of elements within a phrase</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.5 Syntax/text structure: sequence of elements within a phrase</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>D.5 Syntax/text structure: sequence of elements within a phrase</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+            <comment>tbc., e.g., for discourse annotation</comment>
+         </item>
+         <item>
+            <aspect>E. Levels of linguistic analysis: relational structure</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+         </item>
+         <item>
+            <aspect>E.1 Morphology: relations</aspect>
+            <standard>Ligt</standard>
+            <support>(-)</support>
+            <comment>no examples, via link with OntoLex-Morph?</comment>
+         </item>
+         <item>
+            <aspect>E.1 Morphology: relations</aspect>
+            <standard>POWLA</standard>
+            <support>(-)</support>
+            <comment>via link with OntoLex-Morph?</comment>
+         </item>
+         <item>
+            <aspect>E.1 Morphology: relations</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+            <comment>no morphologial segmentation</comment>
+         </item>
+         <item>
+            <aspect>E.1 Morphology: relations</aspect>
+            <standard>LAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>E.1 Morphology: relations</aspect>
+            <standard>MAF</standard>
+            <support>+</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>E.1 Morphology: relations</aspect>
+            <standard>SynAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>E.1 Morphology: relations</aspect>
+            <standard>SemAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>E.2 Dependency syntax</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>E.2 Dependency syntax</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>via external vocabulary, e.g., OLiA</comment>
+         </item>
+         <item>
+            <aspect>E.2 Dependency syntax</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+            <comment>not part of NIF core, but example implementation with OLiA for Stanford Parser</comment>
+         </item>
+         <item>
+            <aspect>E.2 Dependency syntax</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>E.2 Dependency syntax</aspect>
+            <standard>SemAF</standard>
+            <support>(-)</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>E.2 Dependency syntax</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>E.2 Dependency syntax</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>voa external vocabulary: ISOcat</comment>
+         </item>
+         <item>
+            <aspect>E.3 Phrase structure syntax: hierarchical relations</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+            <comment>labelled edges do not seem be foreseen, must be encoded as phrase-level features</comment>
+         </item>
+         <item>
+            <aspect>E.3 Phrase structure syntax: hierarchical relations</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>E.3 Phrase structure syntax: hierarchical relations</aspect>
+            <standard>LAF</standard>
+            <support>+</support>
+            <comment>via external vocabulary, ISOcat</comment>
+         </item>
+         <item>
+            <aspect>E.3 Phrase structure syntax: hierarchical relations</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>labels via external vocabulary, OLiA</comment>
+         </item>
+         <item>
+            <aspect>E.3 Phrase structure syntax: hierarchical relations</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>E.3 Phrase structure syntax: hierarchical relations</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>E.3 Phrase structure syntax: hierarchical relations</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>E.4 Phrase structure syntax: other relations</aspect>
+            <standard>SynAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>E.4 Phrase structure syntax: other relations</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>via external vocabulary, e.g., OLiA</comment>
+         </item>
+         <item>
+            <aspect>E.4 Phrase structure syntax: other relations</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>via external vocabulary, ISOCat</comment>
+         </item>
+         <item>
+            <aspect>E.4 Phrase structure syntax: other relations</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>E.4 Phrase structure syntax: other relations</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>E.4 Phrase structure syntax: other relations</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>E.4 Phrase structure syntax: other relations</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+         </item>
+         <item>
+            <aspect>E.5 Semantics: relations</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+         </item>
+         <item>
+            <aspect>E.5 Semantics: relations</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>via OLiA</comment>
+         </item>
+         <item>
+            <aspect>E.5 Semantics: relations</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+            <comment>can be extended, e.g., a FrameNet extension, using a separate namespace</comment>
+         </item>
+         <item>
+            <aspect>E.5 Semantics: relations</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>E.5 Semantics: relations</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>E.5 Semantics: relations</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>via ISOcat</comment>
+         </item>
+         <item>
+            <aspect>E.5 Semantics: relations</aspect>
+            <standard>SynAF</standard>
+            <support>(-)</support>
+            <comment>tbc.</comment>
+         </item>
+         <item>
+            <aspect>F.1 Intertextual relations</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+         </item>
+         <item>
+            <aspect>F.1 Intertextual relations</aspect>
+            <standard>LAF</standard>
+            <support>(-)</support>
+            <comment>tbc.</comment>
+         </item>
+         <item>
+            <aspect>F.1 Intertextual relations</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>F.1 Intertextual relations</aspect>
+            <standard>SynAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>F.1 Intertextual relations</aspect>
+            <standard>SemAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>F.1 Intertextual relations</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>F.2 Collation and alignment</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(-)</support>
+         </item>
+         <item>
+            <aspect>F.2 Collation and alignment</aspect>
+            <standard>LAF</standard>
+            <support>-</support>
+            <comment>tbc., no examples known</comment>
+         </item>
+         <item>
+            <aspect>F.2 Collation and alignment</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>F.2 Collation and alignment</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+         </item>
+         <item>
+            <aspect>F.2 Collation and alignment</aspect>
+            <standard>SynAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>F.2 Collation and alignment</aspect>
+            <standard>SemAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>F.2 Collation and alignment</aspect>
+            <standard>POWLA</standard>
+            <support>(-)</support>
+            <comment>can be extended</comment>
+         </item>
+         <item>
+            <aspect>F.3 Links with lexical resources</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>F.3 Links with lexical resources</aspect>
+            <standard>Ligt</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>F.3 Links with lexical resources</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+         </item>
+         <item>
+            <aspect>F.3 Links with lexical resources</aspect>
+            <standard>SemAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>F.3 Links with lexical resources</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>F.3 Links with lexical resources</aspect>
+            <standard>MAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>F.3 Links with lexical resources</aspect>
+            <standard>LAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>F.4 Dialog annotation</aspect>
+            <standard>NIF 2.0</standard>
+            <standard>NIF 2.1</standard>
+            <support>-</support>
+            <comment>Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</comment>
+         </item>
+         <item>
+            <aspect>F.4 Dialog annotation</aspect>
+            <standard>SemAF</standard>
+            <support>+</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>F.4 Dialog annotation</aspect>
+            <standard>POWLA</standard>
+            <support>(+)</support>
+            <comment>extensible</comment>
+         </item>
+         <item>
+            <aspect>F.4 Dialog annotation</aspect>
+            <standard>LAF</standard>
+            <support>(+)</support>
+            <comment>tbc., via ISOcat?</comment>
+         </item>
+         <item>
+            <aspect>F.4 Dialog annotation</aspect>
+            <standard>SynAF</standard>
+            <support/>
+         </item>
+         <item>
+            <aspect>F.4 Dialog annotation</aspect>
+            <standard>MAF</standard>
+            <support>-</support>
+            <comment>tbc</comment>
+         </item>
+         <item>
+            <aspect>F.4 Dialog annotation</aspect>
+            <standard>Ligt</standard>
+            <support>-</support>
+         </item>
+      </survey>
+   </parse-pass-1>
+   <parse-pass-2>
+      <survey>
+         <row>
+            <key>Table of contents</key>
+            <cell class="NIF_2.0"/>
+            <cell class="NIF_2.1"/>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt"/>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>A.1 RDF serialization</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>RDF</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>RDF</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+            </cell>
+         </row>
+         <row>
+            <key>A.2 Extent of standardization</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>widely used community standard, and referred to in W3C standards</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>widely used community standard, and referred to in W3C standards</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>this basically implements LAF</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+         </row>
+         <row>
+            <key>A.3 Documentation</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>for NIF 2.0</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>for NIF 2.0</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>partially documented only</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>on-line documentation dated, more up-to-date documentation in Cimiano et al. 2020, but this is not open access</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>via https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf</comment>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>link tbc.</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>unless link/information provided</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+               <comment>unless link/information provided</comment>
+            </cell>
+         </row>
+         <row>
+            <key>A.4 IRI fragment identifiers for strings</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(-)</support>
+               <comment>not specified, to be provided by complementary vocabulary, e.g., NIF or WA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>proprietary means of defining selectors</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>A.5 Explicit selectors</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>recent publications recommend to rely on external vocabularies instead</comment>
+            </cell>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>A.6 Explicit context strings</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>-</support>
+            </cell>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>A.7 API specifications for web services</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt"/>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>A.8 Assign data categories</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>nif:oliaLink, pointing to OLiA</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>nif:oliaLink, pointing to OLiA</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+               <comment>Not specified, but designed as a NIF fragment, so, nif:oliaLink could be used</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>LAF and other ISO/TC37 standards: pointing to ISOCat, no longer maintained, successor solutions are only emerging: CCR, DatCatInfo</comment>
+            </cell>
+            <cell class="MAF">
+               <support>(+)</support>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+            </cell>
+         </row>
+         <row>
+            <key>A.9 Compatible with Web Annotation vocabulary</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>A partial reconstruction of LAF within WA has been described by Verspoor et al. 2012, but this does not seem to have been adopted in subsequent research nor evaluated by any third party.</comment>
+            </cell>
+            <cell class="MAF">
+               <support>(+)</support>
+               <comment>not checked in detail, but cf. LAF</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>not checked in detail, but cf. LAF</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>not checked in detail, but cf. LAF</comment>
+            </cell>
+         </row>
+         <row>
+            <key>A.10 Compatible with NIF 2.0 core vocabulary</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+               <comment>extends NIF vocabulary with specifications for morphology (interlinear glossed text); still under development, see here</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>NIF systematically conflates LAF data structures, see A.11</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>A.11 Compatible with ISO standards</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>no generic data structures for linguistic annotation; conflates regions and nodes, see below</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>no generic data structures for linguistic annotation; conflates regions and nodes, see below</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+               <comment>only a specific subset, possibly MAF</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+         </row>
+         <row>
+            <key>B.1 Pointers to primary data</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>pointers to data structures, not primary data</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>offset-based pointers possible, last publications recommend to use external vocabularies</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+               <comment>XPointers</comment>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>from LAF</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>from LAF</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>from LAF</comment>
+            </cell>
+         </row>
+         <row>
+            <key>B.2 Pointers: Vocabulary for explicit references</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>offset-based pointers possible, last publications recommend to use external vocabularies</comment>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>no RDF statements</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>B.3 Pointers: User-provided selectors</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>would be considered out of scope</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>would be considered out of scope</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt"/>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>in combination with Web Annotation</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(-)</support>
+               <comment>actually, this is hard to tell, technically, this would be possible, but there don't seem to be documented examples</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>B.4 Pointers: Support the annotation of continuous strings</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+         </row>
+         <row>
+            <key>B.5 Pointers: Annotation of discontinuous strings</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>annotations such as ext:offset_0_14_23_32 are not considered nor supported</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>annotations such as ext:offset_0_14_23_32 are not considered nor supported</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>in principle, discontinuous aggregates could exist, but there are no examples for that nor any model in current IGT annotation</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>a terminal is offset-defined, so it apparently has to be a continuous string, but nonterminals can aggregate discontinuous sequences of terminals</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>the existence of discontinuous anchors needs to be confirmed, but nodes can aggregate other nodes regardless of their position</comment>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.6 Pointers: Annotation of media files</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(-)</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>B.7 Pointers: Support the annotation of timestamps/timelines</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>if combined with Web Annotation</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc.; CC: I'm pretty sure this has been addressed</comment>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.8 Pointers: standoff annotation</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+               <comment>no examples known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.9 Generic data structures for linguistic annotation: node != pointer</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>unclear</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.10 Generic data structures for linguistic annotation: zero nodes</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>the default encoding for annotations in NIF is by subclasses of nif:String</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>the default encoding for annotations in NIF is by subclasses of nif:String</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+               <comment>from LAF</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.11.a Non-reified representation of edges</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>for hierarchical relations only</comment>
+            </cell>
+            <cell class="LAF">
+               <support/>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.12 Reified representation of edges (annotation relations)</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>reification" is not directly applicable to non-RDF data</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>B.13 Generic data structures for linguistic annotation: graphs</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.14 Generic data structures for linguistic annotation: annotations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>via OLiA</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>via OLiA</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>no example known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>via OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.16 Provenance and confidence</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>NIF 2.0</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>NIF 2.0</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(-)</support>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>no RDF extension possible</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>B.17 Concurrent annotation</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>no example known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.18 Sequence of annotation units</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+               <comment>for native annotation units</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.19 annotation values: plain literals</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>B.20 annotation values: feature structures</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+               <comment>no example known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+               <comment>e.g., using OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+         </row>
+         <row>
+            <key>C.1 Word-level annotations: word unit</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>nif:Word</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>nif:Word</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>powla:Terminal, but can be sub-token</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+         </row>
+         <row>
+            <key>C.2 Sentence-level annotation: sentence unit</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>nif:Sentence</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>nif:Sentence</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>powla:Root, but this doesn't have to be sentential</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(-)</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>tbc.</comment>
+            </cell>
+         </row>
+         <row>
+            <key>C.3 morphology: morphological segments</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>no designated vocabulary, can be accessed as substrings, but not in all cases.</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>no designated vocabulary, can be accessed as substrings, but not in all cases.</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>no designated vocabulary, but can be added</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>no designated vocabulary, but can be modelled as segments</comment>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>C.4 syntax/text structure: node labels/types</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <support>(+)</support>
+               <comment>predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <support>(+)</support>
+               <comment>predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+               <comment>no examples for phrase-level annotations</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+               <comment>using an external vocabulary, OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+               <comment>ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+               <comment>no syntax nodes</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>ISOcat, for syntax, but hard-wired data structures only</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>ISOcat, for text/discourse, but hard-wired data structures only</comment>
+            </cell>
+         </row>
+         <row>
+            <key>C.5 semantics: node labels/types</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>NIF supports entity linking, but no other form of semantic annotation, hence (-)</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>NIF supports entity linking, but no other form of semantic annotation, hence (-)</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+               <comment>morphology only</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+               <comment>using an external vocabulary, OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+               <comment>ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+               <comment>morphology only</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+         </row>
+         <row>
+            <key>D.1 Word-level annotation: sequence of words</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>nif:nextWord</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>nif:nextWord</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>words are not a designated datatype</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc., implicitly via offsets?</comment>
+            </cell>
+            <cell class="MAF">
+               <support>(+)</support>
+               <comment>tbc: implicitly via XML?</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>tbc: implicitly via XML?</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>tbc: implcitly via XML?</comment>
+            </cell>
+         </row>
+         <row>
+            <key>D.2 Sentence-level annotation: sequence of sentences</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>nif:nextSentence</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>nif:nextSentence</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="MAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+         </row>
+         <row>
+            <key>D.3 Morphology: sequence of morphological segments</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>(-)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(-)</support>
+               <comment>tbc</comment>
+            </cell>
+         </row>
+         <row>
+            <key>D.4 Syntax: discontinuous multi-word segments</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>NIF phrases are strings, i.e., necessarily continuous</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>NIF phrases are strings, i.e., necessarily continuous</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>no examples known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>tbc., syntax is likely the reason for having such nodes in LAF</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>tbc., in analogy with SynAF?</comment>
+            </cell>
+         </row>
+         <row>
+            <key>D.5 Syntax/text structure: sequence of elements within a phrase</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>tbc., e.g., for discourse annotation</comment>
+            </cell>
+         </row>
+         <row>
+            <key>E.1 Morphology: relations</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>no morphologial segmentation</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>no morphologial segmentation</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>no examples, via link with OntoLex-Morph?</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(-)</support>
+               <comment>via link with OntoLex-Morph?</comment>
+            </cell>
+            <cell class="LAF">
+               <support/>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+         </row>
+         <row>
+            <key>E.2 Dependency syntax</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>not part of NIF core, but example implementation with OLiA for Stanford Parser</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>not part of NIF core, but example implementation with OLiA for Stanford Parser</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>via external vocabulary, e.g., OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>voa external vocabulary: ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(-)</support>
+               <comment>tbc</comment>
+            </cell>
+         </row>
+         <row>
+            <key>E.3 Phrase structure syntax: hierarchical relations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>labelled edges do not seem be foreseen, must be encoded as phrase-level features</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>labelled edges do not seem be foreseen, must be encoded as phrase-level features</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>labels via external vocabulary, OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+               <comment>via external vocabulary, ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>E.4 Phrase structure syntax: other relations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>via external vocabulary, e.g., OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>via external vocabulary, ISOCat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>E.5 Semantics: relations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>can be extended, e.g., a FrameNet extension, using a separate namespace</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>can be extended, e.g., a FrameNet extension, using a separate namespace</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>via OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>via ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>(-)</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+         </row>
+         <row>
+            <key>Other (to be added)</key>
+            <cell class="NIF_2.0"/>
+            <cell class="NIF_2.1"/>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt"/>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>F.1 Intertextual relations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(-)</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+         </row>
+         <row>
+            <key>F.2 Collation and alignment</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(-)</support>
+               <comment>can be extended</comment>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>tbc., no examples known</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+         </row>
+         <row>
+            <key>F.3 Links with lexical resources</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+            </cell>
+            <cell class="LAF">
+               <support/>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+         </row>
+         <row>
+            <key>F.4 Dialog annotation</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>extensible</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc., via ISOcat?</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+         </row>
+         <row>
+            <key>Other (please add)</key>
+            <cell class="NIF_2.0"/>
+            <cell class="NIF_2.1"/>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt"/>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+         <row>
+            <key>G.1 Recommended best practices for IRI identifiers used for linguistic annotations</key>
+            <cell class="NIF_2.0"/>
+            <cell class="NIF_2.1"/>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt"/>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+         </row>
+      </survey>
+   </parse-pass-2>
+   <parse-pass-3>
+      <survey>
+         <row>
+            <key>A.1 RDF serialization</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>RDF</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>RDF</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+            </cell>
+            <cell class="score">0</cell>
+         </row>
+         <row>
+            <key>A.2 Extent of standardization</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>widely used community standard, and referred to in W3C standards</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>widely used community standard, and referred to in W3C standards</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>this basically implements LAF</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+            <cell class="score">4.5</cell>
+         </row>
+         <row>
+            <key>A.3 Documentation</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>for NIF 2.0</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>for NIF 2.0</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>partially documented only</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>on-line documentation dated, more up-to-date documentation in Cimiano et al. 2020, but this is not open access</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>via https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf</comment>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>link tbc.</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>unless link/information provided</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+               <comment>unless link/information provided</comment>
+            </cell>
+            <cell class="score">1.5</cell>
+         </row>
+         <row>
+            <key>A.4 IRI fragment identifiers for strings</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(-)</support>
+               <comment>not specified, to be provided by complementary vocabulary, e.g., NIF or WA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>proprietary means of defining selectors</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">-0.5</cell>
+         </row>
+         <row>
+            <key>A.5 Explicit selectors</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>recent publications recommend to rely on external vocabularies instead</comment>
+            </cell>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">1.5</cell>
+         </row>
+         <row>
+            <key>A.6 Explicit context strings</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>-</support>
+            </cell>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">0</cell>
+         </row>
+         <row>
+            <key>A.7 API specifications for web services</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt"/>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF"/>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">2</cell>
+         </row>
+         <row>
+            <key>A.8 Assign data categories</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>nif:oliaLink, pointing to OLiA</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>nif:oliaLink, pointing to OLiA</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+               <comment>Not specified, but designed as a NIF fragment, so, nif:oliaLink could be used</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>LAF and other ISO/TC37 standards: pointing to ISOCat, no longer maintained, successor solutions are only emerging: CCR, DatCatInfo</comment>
+            </cell>
+            <cell class="MAF">
+               <support>(+)</support>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+            </cell>
+            <cell class="score">3.5</cell>
+         </row>
+         <row>
+            <key>A.9 Compatible with Web Annotation vocabulary</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>A partial reconstruction of LAF within WA has been described by Verspoor et al. 2012, but this does not seem to have been adopted in subsequent research nor evaluated by any third party.</comment>
+            </cell>
+            <cell class="MAF">
+               <support>(+)</support>
+               <comment>not checked in detail, but cf. LAF</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>not checked in detail, but cf. LAF</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>not checked in detail, but cf. LAF</comment>
+            </cell>
+            <cell class="score">4</cell>
+         </row>
+         <row>
+            <key>A.10 Compatible with NIF 2.0 core vocabulary</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+               <comment>extends NIF vocabulary with specifications for morphology (interlinear glossed text); still under development, see here</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>NIF systematically conflates LAF data structures, see A.11</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">2.5</cell>
+         </row>
+         <row>
+            <key>A.11 Compatible with ISO standards</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>no generic data structures for linguistic annotation; conflates regions and nodes, see below</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>no generic data structures for linguistic annotation; conflates regions and nodes, see below</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+               <comment>only a specific subset, possibly MAF</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+            <cell class="score">1</cell>
+         </row>
+         <row>
+            <key>B.1 Pointers to primary data</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>pointers to data structures, not primary data</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>offset-based pointers possible, last publications recommend to use external vocabularies</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+               <comment>XPointers</comment>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>from LAF</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>from LAF</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>from LAF</comment>
+            </cell>
+            <cell class="score">6</cell>
+         </row>
+         <row>
+            <key>B.2 Pointers: Vocabulary for explicit references</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>offset-based pointers possible, last publications recommend to use external vocabularies</comment>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>no RDF statements</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">0.5</cell>
+         </row>
+         <row>
+            <key>B.3 Pointers: User-provided selectors</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>would be considered out of scope</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>would be considered out of scope</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt"/>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>in combination with Web Annotation</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(-)</support>
+               <comment>actually, this is hard to tell, technically, this would be possible, but there don't seem to be documented examples</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">-2</cell>
+         </row>
+         <row>
+            <key>B.4 Pointers: Support the annotation of continuous strings</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+            <cell class="score">8</cell>
+         </row>
+         <row>
+            <key>B.5 Pointers: Annotation of discontinuous strings</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>annotations such as ext:offset_0_14_23_32 are not considered nor supported</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>annotations such as ext:offset_0_14_23_32 are not considered nor supported</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>in principle, discontinuous aggregates could exist, but there are no examples for that nor any model in current IGT annotation</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>a terminal is offset-defined, so it apparently has to be a continuous string, but nonterminals can aggregate discontinuous sequences of terminals</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>the existence of discontinuous anchors needs to be confirmed, but nodes can aggregate other nodes regardless of their position</comment>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">-1.5</cell>
+         </row>
+         <row>
+            <key>B.6 Pointers: Annotation of media files</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(-)</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">-3.5</cell>
+         </row>
+         <row>
+            <key>B.7 Pointers: Support the annotation of timestamps/timelines</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>if combined with Web Annotation</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc.; CC: I'm pretty sure this has been addressed</comment>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">-2</cell>
+         </row>
+         <row>
+            <key>B.8 Pointers: standoff annotation</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+               <comment>no examples known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">4.5</cell>
+         </row>
+         <row>
+            <key>B.9 Generic data structures for linguistic annotation: node != pointer</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>unclear</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">-0.5</cell>
+         </row>
+         <row>
+            <key>B.10 Generic data structures for linguistic annotation: zero nodes</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>the default encoding for annotations in NIF is by subclasses of nif:String</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>the default encoding for annotations in NIF is by subclasses of nif:String</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+               <comment>from LAF</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">4</cell>
+         </row>
+         <row>
+            <key>B.11.a Non-reified representation of edges</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>for hierarchical relations only</comment>
+            </cell>
+            <cell class="LAF">
+               <support/>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">-1.5</cell>
+         </row>
+         <row>
+            <key>B.12 Reified representation of edges (annotation relations)</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>reification" is not directly applicable to non-RDF data</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">-1.5</cell>
+         </row>
+         <row>
+            <key>B.13 Generic data structures for linguistic annotation: graphs</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">3.5</cell>
+         </row>
+         <row>
+            <key>B.14 Generic data structures for linguistic annotation: annotations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">0</cell>
+         </row>
+         <row>
+            <key>B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>via OLiA</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>via OLiA</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>no example known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>via OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">2</cell>
+         </row>
+         <row>
+            <key>B.16 Provenance and confidence</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>NIF 2.0</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>NIF 2.0</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(-)</support>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>no RDF extension possible</comment>
+            </cell>
+            <cell class="MAF"/>
+            <cell class="SynAF"/>
+            <cell class="SemAF"/>
+            <cell class="score">-3</cell>
+         </row>
+         <row>
+            <key>B.17 Concurrent annotation</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>no example known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">-0.5</cell>
+         </row>
+         <row>
+            <key>B.18 Sequence of annotation units</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+               <comment>for native annotation units</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">3.5</cell>
+         </row>
+         <row>
+            <key>B.19 annotation values: plain literals</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">5</cell>
+         </row>
+         <row>
+            <key>B.20 annotation values: feature structures</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+               <comment>no example known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+               <comment>e.g., using OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+            <cell class="score">7.5</cell>
+         </row>
+         <row>
+            <key>C.1 Word-level annotations: word unit</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>nif:Word</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>nif:Word</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>powla:Terminal, but can be sub-token</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+            <cell class="score">7.5</cell>
+         </row>
+         <row>
+            <key>C.2 Sentence-level annotation: sentence unit</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>nif:Sentence</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>nif:Sentence</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>powla:Root, but this doesn't have to be sentential</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(-)</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="score">5</cell>
+         </row>
+         <row>
+            <key>C.3 morphology: morphological segments</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>no designated vocabulary, can be accessed as substrings, but not in all cases.</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>no designated vocabulary, can be accessed as substrings, but not in all cases.</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>no designated vocabulary, but can be added</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>no designated vocabulary, but can be modelled as segments</comment>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">1</cell>
+         </row>
+         <row>
+            <key>C.4 syntax/text structure: node labels/types</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <support>(+)</support>
+               <comment>predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <support>(+)</support>
+               <comment>predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+               <comment>no examples for phrase-level annotations</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+               <comment>using an external vocabulary, OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+               <comment>ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+               <comment>no syntax nodes</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>ISOcat, for syntax, but hard-wired data structures only</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>ISOcat, for text/discourse, but hard-wired data structures only</comment>
+            </cell>
+            <cell class="score">3</cell>
+         </row>
+         <row>
+            <key>C.5 semantics: node labels/types</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>NIF supports entity linking, but no other form of semantic annotation, hence (-)</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>NIF supports entity linking, but no other form of semantic annotation, hence (-)</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+               <comment>morphology only</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+               <comment>using an external vocabulary, OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+               <comment>ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+               <comment>morphology only</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="score">-1</cell>
+         </row>
+         <row>
+            <key>D.1 Word-level annotation: sequence of words</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>nif:nextWord</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>nif:nextWord</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>words are not a designated datatype</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc., implicitly via offsets?</comment>
+            </cell>
+            <cell class="MAF">
+               <support>(+)</support>
+               <comment>tbc: implicitly via XML?</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>tbc: implicitly via XML?</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>tbc: implcitly via XML?</comment>
+            </cell>
+            <cell class="score">5.5</cell>
+         </row>
+         <row>
+            <key>D.2 Sentence-level annotation: sequence of sentences</key>
+            <cell class="NIF_2.0">
+               <support>+</support>
+               <comment>nif:nextSentence</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>+</support>
+               <comment>nif:nextSentence</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="MAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="score">5</cell>
+         </row>
+         <row>
+            <key>D.3 Morphology: sequence of morphological segments</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+            </cell>
+            <cell class="SynAF">
+               <support>(-)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(-)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="score">-0.5</cell>
+         </row>
+         <row>
+            <key>D.4 Syntax: discontinuous multi-word segments</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>NIF phrases are strings, i.e., necessarily continuous</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>NIF phrases are strings, i.e., necessarily continuous</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>no examples known</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support>(+)</support>
+               <comment>tbc., syntax is likely the reason for having such nodes in LAF</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(+)</support>
+               <comment>tbc., in analogy with SynAF?</comment>
+            </cell>
+            <cell class="score">0.5</cell>
+         </row>
+         <row>
+            <key>D.5 Syntax/text structure: sequence of elements within a phrase</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>+</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>+</support>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>tbc., e.g., for discourse annotation</comment>
+            </cell>
+            <cell class="score">2.5</cell>
+         </row>
+         <row>
+            <key>E.1 Morphology: relations</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>no morphologial segmentation</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>no morphologial segmentation</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(-)</support>
+               <comment>no examples, via link with OntoLex-Morph?</comment>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(-)</support>
+               <comment>via link with OntoLex-Morph?</comment>
+            </cell>
+            <cell class="LAF">
+               <support/>
+            </cell>
+            <cell class="MAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="score">-4</cell>
+         </row>
+         <row>
+            <key>E.2 Dependency syntax</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+               <comment>not part of NIF core, but example implementation with OLiA for Stanford Parser</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+               <comment>not part of NIF core, but example implementation with OLiA for Stanford Parser</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>via external vocabulary, e.g., OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>voa external vocabulary: ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>(-)</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="score">0.5</cell>
+         </row>
+         <row>
+            <key>E.3 Phrase structure syntax: hierarchical relations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>labelled edges do not seem be foreseen, must be encoded as phrase-level features</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>labelled edges do not seem be foreseen, must be encoded as phrase-level features</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>labels via external vocabulary, OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>+</support>
+               <comment>via external vocabulary, ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">-0.5</cell>
+         </row>
+         <row>
+            <key>E.4 Phrase structure syntax: other relations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>via external vocabulary, e.g., OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>via external vocabulary, ISOCat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>+</support>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">-1</cell>
+         </row>
+         <row>
+            <key>E.5 Semantics: relations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+               <comment>can be extended, e.g., a FrameNet extension, using a separate namespace</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+               <comment>can be extended, e.g., a FrameNet extension, using a separate namespace</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>via OLiA</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>via ISOcat</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>(-)</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+            </cell>
+            <cell class="score">-1.5</cell>
+         </row>
+         <row>
+            <key>F.1 Intertextual relations</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA"/>
+            <cell class="LAF">
+               <support>(-)</support>
+               <comment>tbc.</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="score">-5.5</cell>
+         </row>
+         <row>
+            <key>F.2 Collation and alignment</key>
+            <cell class="NIF_2.0">
+               <support>(-)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(-)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(-)</support>
+               <comment>can be extended</comment>
+            </cell>
+            <cell class="LAF">
+               <support>-</support>
+               <comment>tbc., no examples known</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+            </cell>
+            <cell class="SynAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SemAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="score">-6.5</cell>
+         </row>
+         <row>
+            <key>F.3 Links with lexical resources</key>
+            <cell class="NIF_2.0">
+               <support>(+)</support>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>(+)</support>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>(+)</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+            </cell>
+            <cell class="LAF">
+               <support/>
+            </cell>
+            <cell class="MAF">
+               <support/>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support/>
+            </cell>
+            <cell class="score">2</cell>
+         </row>
+         <row>
+            <key>F.4 Dialog annotation</key>
+            <cell class="NIF_2.0">
+               <support>-</support>
+               <comment>Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</comment>
+            </cell>
+            <cell class="NIF_2.1">
+               <support>-</support>
+               <comment>Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</comment>
+            </cell>
+            <cell class="CoNLL-RDF"/>
+            <cell class="Ligt">
+               <support>-</support>
+            </cell>
+            <cell class="Web_Annotation"/>
+            <cell class="POWLA">
+               <support>(+)</support>
+               <comment>extensible</comment>
+            </cell>
+            <cell class="LAF">
+               <support>(+)</support>
+               <comment>tbc., via ISOcat?</comment>
+            </cell>
+            <cell class="MAF">
+               <support>-</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="SynAF">
+               <support/>
+            </cell>
+            <cell class="SemAF">
+               <support>+</support>
+               <comment>tbc</comment>
+            </cell>
+            <cell class="score">-2</cell>
+         </row>
+         <row class="score">
+            <key>score</key>
+            <cell class="NIF_2.0">3.5</cell>
+            <cell class="NIF_2.1">3.5</cell>
+            <cell class="CoNLL-RDF">0</cell>
+            <cell class="Ligt">-4</cell>
+            <cell class="Web_Annotation">0</cell>
+            <cell class="POWLA">11</cell>
+            <cell class="LAF">14</cell>
+            <cell class="MAF">-1.5</cell>
+            <cell class="SynAF">4.5</cell>
+            <cell class="SemAF">5.5</cell>
+            <cell/>
+         </row>
+      </survey>
+   </parse-pass-3>
+   <results-as-html>
+      <html xmlns="http://www.w3.org/1999/xhtml">
+         <head>
+            <title>Linguistic Annotation Survey generated 2020-12-09T07:23:05.872-05:00</title>
+            <style>
+               table {
+               border-spacing: 0;
+               width: 100%;
+               border: 1px solid #ddd;
+               }
+               th {
+               cursor: pointer;
+               text-align: center;
+               padding: 1em;
+               }
+               td {
+               text-align: right;
+               padding: 1em;
+               }
+               tr:nth-child(even) {
+               background-color: #f2f2f2;
+               }
+               .support{
+               text-align: center;}
+               .comment{
+               text-align: left;
+               }
+               .hascomment{
+               background-color: lightgray;
+               cursor: pointer;
+               }
+               .hide{
+               display: none;
+               }
+               .sup4{
+               background-color: #33ff33;
+               }
+               .sup3{
+               background-color: #ccffcc;
+               }
+               .sup2{
+               background-color: #ffff66;
+               }
+               .sup1{
+               background-color: #ff6666;
+               }
+            </style>
+         </head>
+         <body>
+            <h1>Linguistic Annotation Survey</h1>
+            <div>Generated 2020-12-09T07:23:05.872-05:00 from stylsheet at file:/U:/linguistic-annotation/apps/parse%20survey.xsl</div>
+            <h2>Key</h2>
+            <div>Some criteria below assign specific meaning to the four codes. Default values, however, are as follows:</div>
+            <div>
+               <code>+</code>: criterium is fully supported (score 1)</div>
+            <div>
+               <code>(+)</code>: criterium is partly supported, or offers potential for full support via extensions (score 0.5)</div>
+            <div>
+               <code>(-)</code>: criterium is not supported, but might be extended to partial or full support (score -0.5)</div>
+            <div>
+               <code>-</code>: criterium is not supported, and cannot be extended to develop partial or full support (score -1)</div>
+            <h2>Survey</h2>
+            <table id="survey">
+               <thead>
+                  <tr>
+                     <th onclick="sortTable(0)"/>
+                     <th onclick="sortTable(1)" class="NIF_2.0">NIF_2.0</th>
+                     <th onclick="sortTable(2)" class="NIF_2.1">NIF_2.1</th>
+                     <th onclick="sortTable(3)" class="CoNLL-RDF">CoNLL-RDF</th>
+                     <th onclick="sortTable(4)" class="Ligt">Ligt</th>
+                     <th onclick="sortTable(5)" class="Web_Annotation">Web_Annotation</th>
+                     <th onclick="sortTable(6)" class="POWLA">POWLA</th>
+                     <th onclick="sortTable(7)" class="LAF">LAF</th>
+                     <th onclick="sortTable(8)" class="MAF">MAF</th>
+                     <th onclick="sortTable(9)" class="SynAF">SynAF</th>
+                     <th onclick="sortTable(10)" class="SemAF">SemAF</th>
+                     <th onclick="sortTableByNumber(11)" class="score">score</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  <tr>
+                     <td class="">A.1 RDF serialization</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e6')">+</div>
+                        <div class="comment hide" id="d1458e6">RDF</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e9')">+</div>
+                        <div class="comment hide" id="d1458e9">RDF</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SynAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SemAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="score">0</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.2 Extent of standardization</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e31')">(+)</div>
+                        <div class="comment hide" id="d1458e31">widely used community standard, and referred to in W3C standards</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e34')">(+)</div>
+                        <div class="comment hide" id="d1458e34">widely used community standard, and referred to in W3C standards</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e41')">(+)</div>
+                        <div class="comment hide" id="d1458e41">this basically implements LAF</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="score">4.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.3 Documentation</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e57')">+</div>
+                        <div class="comment hide" id="d1458e57">for NIF 2.0</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e60')">+</div>
+                        <div class="comment hide" id="d1458e60">for NIF 2.0</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e64')">(-)</div>
+                        <div class="comment hide" id="d1458e64">partially documented only</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e68')">(+)</div>
+                        <div class="comment hide" id="d1458e68">on-line documentation dated, more up-to-date documentation in Cimiano et al. 2020, but this is not open access</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e71')">(+)</div>
+                        <div class="comment hide" id="d1458e71">via https://www.cs.vassar.edu/~ide/papers/ISO+24612-2012.pdf</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e74')">+</div>
+                        <div class="comment hide" id="d1458e74">link tbc.</div>
+                     </td>
+                     <td class="SynAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e77')">-</div>
+                        <div class="comment hide" id="d1458e77">unless link/information provided</div>
+                     </td>
+                     <td class="SemAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e80')">-</div>
+                        <div class="comment hide" id="d1458e80">unless link/information provided</div>
+                     </td>
+                     <td class="score">1.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.4 IRI fragment identifiers for strings</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e96')">(-)</div>
+                        <div class="comment hide" id="d1458e96">not specified, to be provided by complementary vocabulary, e.g., NIF or WA</div>
+                     </td>
+                     <td class="LAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e99')">-</div>
+                        <div class="comment hide" id="d1458e99">proprietary means of defining selectors</div>
+                     </td>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">-0.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.5 Explicit selectors</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e118')">(+)</div>
+                        <div class="comment hide" id="d1458e118">recent publications recommend to rely on external vocabularies instead</div>
+                     </td>
+                     <td class="LAF"/>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">1.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.6 Explicit context strings</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="LAF"/>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">0</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.7 API specifications for web services</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e149')">+</div>
+                        <div class="comment hide" id="d1458e149">https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e152')">+</div>
+                        <div class="comment hide" id="d1458e152">https://persistence.uni-leipzig.org/nlp2rdf/specification/api.html</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt"/>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA"/>
+                     <td class="LAF"/>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">2</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.8 Assign data categories</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e168')">(+)</div>
+                        <div class="comment hide" id="d1458e168">nif:oliaLink, pointing to OLiA</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e171')">(+)</div>
+                        <div class="comment hide" id="d1458e171">nif:oliaLink, pointing to OLiA</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e175')">(+)</div>
+                        <div class="comment hide" id="d1458e175">Not specified, but designed as a NIF fragment, so, nif:oliaLink could be used</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA"/>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e180')">(+)</div>
+                        <div class="comment hide" id="d1458e180">LAF and other ISO/TC37 standards: pointing to ISOCat, no longer maintained, successor solutions are only emerging: CCR, DatCatInfo</div>
+                     </td>
+                     <td class="MAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="SynAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="SemAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="score">3.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.9 Compatible with Web Annotation vocabulary</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e194')">(+)</div>
+                        <div class="comment hide" id="d1458e194">Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e197')">(+)</div>
+                        <div class="comment hide" id="d1458e197">Hellmann et al. 2013 describe the use of NIF string URIs as Web Annotation targets</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e206')">(+)</div>
+                        <div class="comment hide" id="d1458e206">A partial reconstruction of LAF within WA has been described by Verspoor et al. 2012, but this does not seem to have been adopted in subsequent research nor evaluated by any third party.</div>
+                     </td>
+                     <td class="MAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e209')">(+)</div>
+                        <div class="comment hide" id="d1458e209">not checked in detail, but cf. LAF</div>
+                     </td>
+                     <td class="SynAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e212')">(+)</div>
+                        <div class="comment hide" id="d1458e212">not checked in detail, but cf. LAF</div>
+                     </td>
+                     <td class="SemAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e215')">(+)</div>
+                        <div class="comment hide" id="d1458e215">not checked in detail, but cf. LAF</div>
+                     </td>
+                     <td class="score">4</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.10 Compatible with NIF 2.0 core vocabulary</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e228')">+</div>
+                        <div class="comment hide" id="d1458e228">extends NIF vocabulary with specifications for morphology (interlinear glossed text); still under development, see here</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="LAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e234')">-</div>
+                        <div class="comment hide" id="d1458e234">NIF systematically conflates LAF data structures, see A.11</div>
+                     </td>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">2.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">A.11 Compatible with ISO standards</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e245')">-</div>
+                        <div class="comment hide" id="d1458e245">no generic data structures for linguistic annotation; conflates regions and nodes, see below</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e248')">-</div>
+                        <div class="comment hide" id="d1458e248">no generic data structures for linguistic annotation; conflates regions and nodes, see below</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e252')">-</div>
+                        <div class="comment hide" id="d1458e252">only a specific subset, possibly MAF</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA"/>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="score">1</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.1 Pointers to primary data</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e276')">(-)</div>
+                        <div class="comment hide" id="d1458e276">pointers to data structures, not primary data</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e280')">(+)</div>
+                        <div class="comment hide" id="d1458e280">offset-based pointers possible, last publications recommend to use external vocabularies</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e283')">+</div>
+                        <div class="comment hide" id="d1458e283">XPointers</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e286')">+</div>
+                        <div class="comment hide" id="d1458e286">from LAF</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e289')">+</div>
+                        <div class="comment hide" id="d1458e289">from LAF</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e292')">+</div>
+                        <div class="comment hide" id="d1458e292">from LAF</div>
+                     </td>
+                     <td class="score">6</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.2 Pointers: Vocabulary for explicit references</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e308')">(+)</div>
+                        <div class="comment hide" id="d1458e308">offset-based pointers possible, last publications recommend to use external vocabularies</div>
+                     </td>
+                     <td class="LAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e311')">-</div>
+                        <div class="comment hide" id="d1458e311">no RDF statements</div>
+                     </td>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">0.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.3 Pointers: User-provided selectors</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e322')">-</div>
+                        <div class="comment hide" id="d1458e322">would be considered out of scope</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e325')">-</div>
+                        <div class="comment hide" id="d1458e325">would be considered out of scope</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt"/>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e331')">(+)</div>
+                        <div class="comment hide" id="d1458e331">in combination with Web Annotation</div>
+                     </td>
+                     <td class="LAF sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e334')">(-)</div>
+                        <div class="comment hide" id="d1458e334">actually, this is hard to tell, technically, this would be possible, but there don't seem to be documented examples</div>
+                     </td>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">-2</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.4 Pointers: Support the annotation of continuous strings</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="score">8</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.5 Pointers: Annotation of discontinuous strings</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e368')">-</div>
+                        <div class="comment hide" id="d1458e368">annotations such as ext:offset_0_14_23_32 are not considered nor supported</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e371')">-</div>
+                        <div class="comment hide" id="d1458e371">annotations such as ext:offset_0_14_23_32 are not considered nor supported</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e375')">(-)</div>
+                        <div class="comment hide" id="d1458e375">in principle, discontinuous aggregates could exist, but there are no examples for that nor any model in current IGT annotation</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e379')">(+)</div>
+                        <div class="comment hide" id="d1458e379">a terminal is offset-defined, so it apparently has to be a continuous string, but nonterminals can aggregate discontinuous sequences of terminals</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e382')">(+)</div>
+                        <div class="comment hide" id="d1458e382">the existence of discontinuous anchors needs to be confirmed, but nodes can aggregate other nodes regardless of their position</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">-1.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.6 Pointers: Annotation of media files</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA"/>
+                     <td class="LAF sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e405')">(-)</div>
+                        <div class="comment hide" id="d1458e405">tbc.</div>
+                     </td>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">-3.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.7 Pointers: Support the annotation of timestamps/timelines</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e424')">(+)</div>
+                        <div class="comment hide" id="d1458e424">if combined with Web Annotation</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e427')">(+)</div>
+                        <div class="comment hide" id="d1458e427">tbc.; CC: I'm pretty sure this has been addressed</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">-2</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.8 Pointers: standoff annotation</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e446')">(+)</div>
+                        <div class="comment hide" id="d1458e446">no examples known</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">4.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.9 Generic data structures for linguistic annotation: node != pointer</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e470')">(-)</div>
+                        <div class="comment hide" id="d1458e470">unclear</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">-0.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.10 Generic data structures for linguistic annotation: zero nodes</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e489')">(+)</div>
+                        <div class="comment hide" id="d1458e489">the default encoding for annotations in NIF is by subclasses of nif:String</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e492')">(+)</div>
+                        <div class="comment hide" id="d1458e492">the default encoding for annotations in NIF is by subclasses of nif:String</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e499')">+</div>
+                        <div class="comment hide" id="d1458e499">from LAF</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">4</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.11.a Non-reified representation of edges</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e515')">(-)</div>
+                        <div class="comment hide" id="d1458e515">nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e518')">(-)</div>
+                        <div class="comment hide" id="d1458e518">nif:subStringOf could be abused for this purpose, for hierarchical relations only, operates on regions/strings, not annotations. Default strategy in NIF is to introduce ad hoc properties, cf. NIF Stanford Core demo</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e525')">(+)</div>
+                        <div class="comment hide" id="d1458e525">for hierarchical relations only</div>
+                     </td>
+                     <td class="LAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">-1.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.12 Reified representation of edges (annotation relations)</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e552')">(+)</div>
+                        <div class="comment hide" id="d1458e552">reification" is not directly applicable to non-RDF data</div>
+                     </td>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">-1.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.13 Generic data structures for linguistic annotation: graphs</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">3.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.14 Generic data structures for linguistic annotation: annotations</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e586')">(-)</div>
+                        <div class="comment hide" id="d1458e586">nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e589')">(-)</div>
+                        <div class="comment hide" id="d1458e589">nif:String), resp. (+) (nif:AnnotationUnit, not the default encoding, though</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e593')">(-)</div>
+                        <div class="comment hide" id="d1458e593">tbc</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e597')">(+)</div>
+                        <div class="comment hide" id="d1458e597">tbc</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">0</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.15 Generic data structures for linguistic annotation: annotation space ("tagset")</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e613')">(+)</div>
+                        <div class="comment hide" id="d1458e613">via OLiA</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e616')">(+)</div>
+                        <div class="comment hide" id="d1458e616">via OLiA</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e620')">(-)</div>
+                        <div class="comment hide" id="d1458e620">no example known</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e624')">(+)</div>
+                        <div class="comment hide" id="d1458e624">via OLiA</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">2</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.16 Provenance and confidence</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e640')">(-)</div>
+                        <div class="comment hide" id="d1458e640">NIF 2.0</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e643')">(-)</div>
+                        <div class="comment hide" id="d1458e643">NIF 2.0</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support">(-)</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support">(-)</div>
+                     </td>
+                     <td class="LAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e652')">-</div>
+                        <div class="comment hide" id="d1458e652">no RDF extension possible</div>
+                     </td>
+                     <td class="MAF"/>
+                     <td class="SynAF"/>
+                     <td class="SemAF"/>
+                     <td class="score">-3</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.17 Concurrent annotation</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e668')">(-)</div>
+                        <div class="comment hide" id="d1458e668">no example known</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">-0.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.18 Sequence of annotation units</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e687')">(+)</div>
+                        <div class="comment hide" id="d1458e687">only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e690')">(+)</div>
+                        <div class="comment hide" id="d1458e690">only for selected annotation units, e.g., nif:nextWord, nif:nextSentence</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e694')">(+)</div>
+                        <div class="comment hide" id="d1458e694">for native annotation units</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">3.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.19 annotation values: plain literals</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">5</td>
+                  </tr>
+                  <tr>
+                     <td class="">B.20 annotation values: feature structures</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e741')">(+)</div>
+                        <div class="comment hide" id="d1458e741">no example known</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e745')">+</div>
+                        <div class="comment hide" id="d1458e745">e.g., using OLiA</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e750')">+</div>
+                        <div class="comment hide" id="d1458e750">tbc</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e753')">+</div>
+                        <div class="comment hide" id="d1458e753">tbc</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="score">7.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">C.1 Word-level annotations: word unit</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e763')">+</div>
+                        <div class="comment hide" id="d1458e763">nif:Word</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e766')">+</div>
+                        <div class="comment hide" id="d1458e766">nif:Word</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e773')">(+)</div>
+                        <div class="comment hide" id="d1458e773">powla:Terminal, but can be sub-token</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="score">7.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">C.2 Sentence-level annotation: sentence unit</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e789')">+</div>
+                        <div class="comment hide" id="d1458e789">nif:Sentence</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e792')">+</div>
+                        <div class="comment hide" id="d1458e792">nif:Sentence</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e799')">(+)</div>
+                        <div class="comment hide" id="d1458e799">powla:Root, but this doesn't have to be sentential</div>
+                     </td>
+                     <td class="LAF sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e802')">(-)</div>
+                        <div class="comment hide" id="d1458e802">tbc.</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e809')">+</div>
+                        <div class="comment hide" id="d1458e809">tbc.</div>
+                     </td>
+                     <td class="score">5</td>
+                  </tr>
+                  <tr>
+                     <td class="">C.3 morphology: morphological segments</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e818')">(-)</div>
+                        <div class="comment hide" id="d1458e818">no designated vocabulary, can be accessed as substrings, but not in all cases.</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e821')">(-)</div>
+                        <div class="comment hide" id="d1458e821">no designated vocabulary, can be accessed as substrings, but not in all cases.</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e828')">(+)</div>
+                        <div class="comment hide" id="d1458e828">no designated vocabulary, but can be added</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e831')">(+)</div>
+                        <div class="comment hide" id="d1458e831">no designated vocabulary, but can be modelled as segments</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e834')">+</div>
+                        <div class="comment hide" id="d1458e834">tbc.</div>
+                     </td>
+                     <td class="SynAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e837')">-</div>
+                        <div class="comment hide" id="d1458e837">tbc</div>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">1</td>
+                  </tr>
+                  <tr>
+                     <td class="">C.4 syntax/text structure: node labels/types</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e848')">(+)</div>
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e848')">(+)</div>
+                        <div class="comment hide" id="d1458e848">predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e852')">(+)</div>
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e852')">(+)</div>
+                        <div class="comment hide" id="d1458e852">predefined datatypes nif:Word, nif:Phrase, nif:Paragraph, etc.; but note that these do not describe nodes in the sense of LAF, but regions</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e856')">-</div>
+                        <div class="comment hide" id="d1458e856">no examples for phrase-level annotations</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e860')">+</div>
+                        <div class="comment hide" id="d1458e860">using an external vocabulary, OLiA</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e863')">+</div>
+                        <div class="comment hide" id="d1458e863">ISOcat</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e866')">-</div>
+                        <div class="comment hide" id="d1458e866">no syntax nodes</div>
+                     </td>
+                     <td class="SynAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e869')">(+)</div>
+                        <div class="comment hide" id="d1458e869">ISOcat, for syntax, but hard-wired data structures only</div>
+                     </td>
+                     <td class="SemAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e872')">(+)</div>
+                        <div class="comment hide" id="d1458e872">ISOcat, for text/discourse, but hard-wired data structures only</div>
+                     </td>
+                     <td class="score">3</td>
+                  </tr>
+                  <tr>
+                     <td class="">C.5 semantics: node labels/types</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e880')">(-)</div>
+                        <div class="comment hide" id="d1458e880">NIF supports entity linking, but no other form of semantic annotation, hence (-)</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e883')">(-)</div>
+                        <div class="comment hide" id="d1458e883">NIF supports entity linking, but no other form of semantic annotation, hence (-)</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e887')">-</div>
+                        <div class="comment hide" id="d1458e887">morphology only</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e891')">+</div>
+                        <div class="comment hide" id="d1458e891">using an external vocabulary, OLiA</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e894')">+</div>
+                        <div class="comment hide" id="d1458e894">ISOcat</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e897')">-</div>
+                        <div class="comment hide" id="d1458e897">morphology only</div>
+                     </td>
+                     <td class="SynAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e900')">-</div>
+                        <div class="comment hide" id="d1458e900">tbc</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e903')">+</div>
+                        <div class="comment hide" id="d1458e903">tbc</div>
+                     </td>
+                     <td class="score">-1</td>
+                  </tr>
+                  <tr>
+                     <td class="">D.1 Word-level annotation: sequence of words</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e911')">+</div>
+                        <div class="comment hide" id="d1458e911">nif:nextWord</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e914')">+</div>
+                        <div class="comment hide" id="d1458e914">nif:nextWord</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e921')">(+)</div>
+                        <div class="comment hide" id="d1458e921">words are not a designated datatype</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e924')">(+)</div>
+                        <div class="comment hide" id="d1458e924">tbc., implicitly via offsets?</div>
+                     </td>
+                     <td class="MAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e927')">(+)</div>
+                        <div class="comment hide" id="d1458e927">tbc: implicitly via XML?</div>
+                     </td>
+                     <td class="SynAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e930')">(+)</div>
+                        <div class="comment hide" id="d1458e930">tbc: implicitly via XML?</div>
+                     </td>
+                     <td class="SemAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e933')">(+)</div>
+                        <div class="comment hide" id="d1458e933">tbc: implcitly via XML?</div>
+                     </td>
+                     <td class="score">5.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">D.2 Sentence-level annotation: sequence of sentences</td>
+                     <td class="NIF_2.0 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e941')">+</div>
+                        <div class="comment hide" id="d1458e941">nif:nextSentence</div>
+                     </td>
+                     <td class="NIF_2.1 sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e944')">+</div>
+                        <div class="comment hide" id="d1458e944">nif:nextSentence</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA"/>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e952')">(+)</div>
+                        <div class="comment hide" id="d1458e952">tbc</div>
+                     </td>
+                     <td class="MAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e955')">(+)</div>
+                        <div class="comment hide" id="d1458e955">tbc</div>
+                     </td>
+                     <td class="SynAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e958')">(+)</div>
+                        <div class="comment hide" id="d1458e958">tbc</div>
+                     </td>
+                     <td class="SemAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e961')">(+)</div>
+                        <div class="comment hide" id="d1458e961">tbc</div>
+                     </td>
+                     <td class="score">5</td>
+                  </tr>
+                  <tr>
+                     <td class="">D.3 Morphology: sequence of morphological segments</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA"/>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e978')">(+)</div>
+                        <div class="comment hide" id="d1458e978">tbc</div>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SynAF sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e983')">(-)</div>
+                        <div class="comment hide" id="d1458e983">tbc</div>
+                     </td>
+                     <td class="SemAF sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e986')">(-)</div>
+                        <div class="comment hide" id="d1458e986">tbc</div>
+                     </td>
+                     <td class="score">-0.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">D.4 Syntax: discontinuous multi-word segments</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e994')">-</div>
+                        <div class="comment hide" id="d1458e994">NIF phrases are strings, i.e., necessarily continuous</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e997')">-</div>
+                        <div class="comment hide" id="d1458e997">NIF phrases are strings, i.e., necessarily continuous</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1001')">(-)</div>
+                        <div class="comment hide" id="d1458e1001">no examples known</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1011')">(+)</div>
+                        <div class="comment hide" id="d1458e1011">tbc., syntax is likely the reason for having such nodes in LAF</div>
+                     </td>
+                     <td class="SemAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1014')">(+)</div>
+                        <div class="comment hide" id="d1458e1014">tbc., in analogy with SynAF?</div>
+                     </td>
+                     <td class="score">0.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">D.5 Syntax/text structure: sequence of elements within a phrase</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1022')">(-)</div>
+                        <div class="comment hide" id="d1458e1022">depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1025')">(-)</div>
+                        <div class="comment hide" id="d1458e1025">depends on internal structure of the phrase, if these are words, this could be nif:nextWord, if these are phrases, this is undefined</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1034')">(+)</div>
+                        <div class="comment hide" id="d1458e1034">tbc</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1037')">-</div>
+                        <div class="comment hide" id="d1458e1037">tbc</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1040')">+</div>
+                        <div class="comment hide" id="d1458e1040">tbc</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1043')">+</div>
+                        <div class="comment hide" id="d1458e1043">tbc., e.g., for discourse annotation</div>
+                     </td>
+                     <td class="score">2.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">E.1 Morphology: relations</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1051')">-</div>
+                        <div class="comment hide" id="d1458e1051">no morphologial segmentation</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1054')">-</div>
+                        <div class="comment hide" id="d1458e1054">no morphologial segmentation</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1058')">(-)</div>
+                        <div class="comment hide" id="d1458e1058">no examples, via link with OntoLex-Morph?</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1062')">(-)</div>
+                        <div class="comment hide" id="d1458e1062">via link with OntoLex-Morph?</div>
+                     </td>
+                     <td class="LAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="MAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1067')">+</div>
+                        <div class="comment hide" id="d1458e1067">tbc</div>
+                     </td>
+                     <td class="SynAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1070')">-</div>
+                        <div class="comment hide" id="d1458e1070">tbc</div>
+                     </td>
+                     <td class="SemAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1073')">-</div>
+                        <div class="comment hide" id="d1458e1073">tbc</div>
+                     </td>
+                     <td class="score">-4</td>
+                  </tr>
+                  <tr>
+                     <td class="">E.2 Dependency syntax</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1081')">(+)</div>
+                        <div class="comment hide" id="d1458e1081">not part of NIF core, but example implementation with OLiA for Stanford Parser</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1084')">(+)</div>
+                        <div class="comment hide" id="d1458e1084">not part of NIF core, but example implementation with OLiA for Stanford Parser</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1091')">(+)</div>
+                        <div class="comment hide" id="d1458e1091">via external vocabulary, e.g., OLiA</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1094')">(+)</div>
+                        <div class="comment hide" id="d1458e1094">voa external vocabulary: ISOcat</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1099')">+</div>
+                        <div class="comment hide" id="d1458e1099">tbc</div>
+                     </td>
+                     <td class="SemAF sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1102')">(-)</div>
+                        <div class="comment hide" id="d1458e1102">tbc</div>
+                     </td>
+                     <td class="score">0.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">E.3 Phrase structure syntax: hierarchical relations</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1110')">(-)</div>
+                        <div class="comment hide" id="d1458e1110">labelled edges do not seem be foreseen, must be encoded as phrase-level features</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1113')">(-)</div>
+                        <div class="comment hide" id="d1458e1113">labelled edges do not seem be foreseen, must be encoded as phrase-level features</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1120')">(+)</div>
+                        <div class="comment hide" id="d1458e1120">labels via external vocabulary, OLiA</div>
+                     </td>
+                     <td class="LAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1123')">+</div>
+                        <div class="comment hide" id="d1458e1123">via external vocabulary, ISOcat</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1128')">+</div>
+                        <div class="comment hide" id="d1458e1128">tbc</div>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">-0.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">E.4 Phrase structure syntax: other relations</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support">(-)</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support">(-)</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1147')">(+)</div>
+                        <div class="comment hide" id="d1458e1147">via external vocabulary, e.g., OLiA</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1150')">(+)</div>
+                        <div class="comment hide" id="d1458e1150">via external vocabulary, ISOCat</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SynAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">-1</td>
+                  </tr>
+                  <tr>
+                     <td class="">E.5 Semantics: relations</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1164')">(-)</div>
+                        <div class="comment hide" id="d1458e1164">can be extended, e.g., a FrameNet extension, using a separate namespace</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1167')">(-)</div>
+                        <div class="comment hide" id="d1458e1167">can be extended, e.g., a FrameNet extension, using a separate namespace</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1174')">(+)</div>
+                        <div class="comment hide" id="d1458e1174">via OLiA</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1177')">(+)</div>
+                        <div class="comment hide" id="d1458e1177">via ISOcat</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SynAF sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1182')">(-)</div>
+                        <div class="comment hide" id="d1458e1182">tbc.</div>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support">+</div>
+                     </td>
+                     <td class="score">-1.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">F.1 Intertextual relations</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support">(-)</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support">(-)</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA"/>
+                     <td class="LAF sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1201')">(-)</div>
+                        <div class="comment hide" id="d1458e1201">tbc.</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SynAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SemAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1208')">-</div>
+                        <div class="comment hide" id="d1458e1208">tbc</div>
+                     </td>
+                     <td class="score">-5.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">F.2 Collation and alignment</td>
+                     <td class="NIF_2.0 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support">(-)</div>
+                     </td>
+                     <td class="NIF_2.1 sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support">(-)</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup2">
+                        <div xmlns="" class="hide score">3</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1224')">(-)</div>
+                        <div class="comment hide" id="d1458e1224">can be extended</div>
+                     </td>
+                     <td class="LAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1227')">-</div>
+                        <div class="comment hide" id="d1458e1227">tbc., no examples known</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="SynAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1232')">-</div>
+                        <div class="comment hide" id="d1458e1232">tbc</div>
+                     </td>
+                     <td class="SemAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1235')">-</div>
+                        <div class="comment hide" id="d1458e1235">tbc</div>
+                     </td>
+                     <td class="score">-6.5</td>
+                  </tr>
+                  <tr>
+                     <td class="">F.3 Links with lexical resources</td>
+                     <td class="NIF_2.0 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="NIF_2.1 sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support">(+)</div>
+                     </td>
+                     <td class="LAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="MAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="score">2</td>
+                  </tr>
+                  <tr>
+                     <td class="">F.4 Dialog annotation</td>
+                     <td class="NIF_2.0 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1266')">-</div>
+                        <div class="comment hide" id="d1458e1266">Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</div>
+                     </td>
+                     <td class="NIF_2.1 sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1269')">-</div>
+                        <div class="comment hide" id="d1458e1269">Web Annotation allows to annotate multiple targets simultaneously, but it lacks the vocabulary to create links between annotations, e.g., for marking turn shifts), hence (+</div>
+                     </td>
+                     <td class="CoNLL-RDF"/>
+                     <td class="Ligt sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support">-</div>
+                     </td>
+                     <td class="Web_Annotation"/>
+                     <td class="POWLA sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1276')">(+)</div>
+                        <div class="comment hide" id="d1458e1276">extensible</div>
+                     </td>
+                     <td class="LAF sup3">
+                        <div xmlns="" class="hide score">5</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1279')">(+)</div>
+                        <div class="comment hide" id="d1458e1279">tbc., via ISOcat?</div>
+                     </td>
+                     <td class="MAF sup1">
+                        <div xmlns="" class="hide score">2</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1282')">-</div>
+                        <div class="comment hide" id="d1458e1282">tbc</div>
+                     </td>
+                     <td class="SynAF">
+                        <div xmlns="" class="hide score">4</div>
+                        <div class="support"/>
+                     </td>
+                     <td class="SemAF sup4">
+                        <div xmlns="" class="hide score">6</div>
+                        <div class="support hascomment" onclick="reveal('d1458e1287')">+</div>
+                        <div class="comment hide" id="d1458e1287">tbc</div>
+                     </td>
+                     <td class="score">-2</td>
+                  </tr>
+                  <tr class="score">
+                     <td class="">score</td>
+                     <td class="NIF_2.0">3.5</td>
+                     <td class="NIF_2.1">3.5</td>
+                     <td class="CoNLL-RDF">0</td>
+                     <td class="Ligt">-4</td>
+                     <td class="Web_Annotation">0</td>
+                     <td class="POWLA">11</td>
+                     <td class="LAF">14</td>
+                     <td class="MAF">-1.5</td>
+                     <td class="SynAF">4.5</td>
+                     <td class="SemAF">5.5</td>
+                     <td class=""/>
+                  </tr>
+               </tbody>
+            </table>
+            <script xml:space="preserve">// script below adapted from https://www.w3schools.com/howto/tryit.asp?filename=tryhow_js_sort_table_desc&#xD;
+function sortTable(n) {&#xD;
+   var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;&#xD;
+   table = document.getElementById("survey");&#xD;
+   switching = true;&#xD;
+   dir = "asc";&#xD;
+   while (switching) {&#xD;
+      switching = false;&#xD;
+      rows = table.rows;&#xD;
+      for (i = 1; i &lt; (rows.length - 1);&#xD;
+      i++) {&#xD;
+         shouldSwitch = false;&#xD;
+         x = rows[i].getElementsByTagName("TD")[n];&#xD;
+         y = rows[i + 1].getElementsByTagName("TD")[n];&#xD;
+         xLc = x.innerText.toLowerCase();&#xD;
+         yLc = y.innerText.toLowerCase();&#xD;
+         if (dir == "asc") {&#xD;
+            if (xLc &gt; yLc) {&#xD;
+               shouldSwitch = true;&#xD;
+               break;&#xD;
+            }&#xD;
+         } else if (dir == "desc") {&#xD;
+            if (xLc &lt; yLc) {&#xD;
+               shouldSwitch = true;&#xD;
+               break;&#xD;
+            }&#xD;
+         }&#xD;
+      }&#xD;
+      if (shouldSwitch) {&#xD;
+         rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);&#xD;
+         switching = true;&#xD;
+         switchcount++;&#xD;
+      } else {&#xD;
+         if (switchcount == 0 &amp;&amp; dir == "asc") {&#xD;
+            dir = "desc";&#xD;
+            switching = true;&#xD;
+         }&#xD;
+      }&#xD;
+   }&#xD;
+}&#xD;
+function sortTableByNumber(n) {&#xD;
+   var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;&#xD;
+   table = document.getElementById("survey");&#xD;
+   switching = true;&#xD;
+   dir = "asc";&#xD;
+   while (switching) {&#xD;
+      switching = false;&#xD;
+      rows = table.rows;&#xD;
+      for (i = 1; i &lt; (rows.length - 1);&#xD;
+      i++) {&#xD;
+         shouldSwitch = false;&#xD;
+         x = rows[i].getElementsByTagName("TD")[n];&#xD;
+         y = rows[i + 1].getElementsByTagName("TD")[n];&#xD;
+         xLc = x.innerText;&#xD;
+         yLc = y.innerText;&#xD;
+         if (dir == "asc") {&#xD;
+            if (Number(xLc) &gt; Number(yLc)) {&#xD;
+               shouldSwitch = true;&#xD;
+               break;&#xD;
+            }&#xD;
+         } else if (dir == "desc") {&#xD;
+            if (Number(xLc) &lt; Number(yLc)) {&#xD;
+               shouldSwitch = true;&#xD;
+               break;&#xD;
+            }&#xD;
+         }&#xD;
+      }&#xD;
+      if (shouldSwitch) {&#xD;
+         rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);&#xD;
+         switching = true;&#xD;
+         switchcount++;&#xD;
+      } else {&#xD;
+         if (switchcount == 0 &amp;&amp; dir == "asc") {&#xD;
+            dir = "desc";&#xD;
+            switching = true;&#xD;
+         }&#xD;
+      }&#xD;
+   }&#xD;
+}&#xD;
+&#xD;
+function reveal(targId) {&#xD;
+   var x = document.getElementById(targId);&#xD;
+   x.classList.toggle("hide");&#xD;
+}&#xD;
+</script>
+         </body>
+      </html>
+   </results-as-html>
+</diagnostics>


### PR DESCRIPTION
Hi @chiarcos , I've restricted changes to a single directory, apps. The prime one, parse survey.xsl, parses required-features.md and presents it in an HTML table with scores. The javascript and css in the HTML parse survey.xsl-output.html are self-contained, so it can be opened in a browser from any local directory (but GitHub won't do anything with it). This is just a rough idea of what's possible. 

No need to pull if you think this is premature. There are many different paths this idea can take, depending.